### PR TITLE
Optimise get_study_ids_from_names

### DIFF
--- a/seerpy/seerpy.py
+++ b/seerpy/seerpy.py
@@ -298,7 +298,7 @@ class SeerConnect:  # pylint: disable=too-many-public-methods
         ], join='outer')
 
         if studies.empty:
-            return studies
+            return studies.assign(id=None)
 
         return studies[['name', 'id']].reset_index(drop=True)
 

--- a/seerpy/seerpy.py
+++ b/seerpy/seerpy.py
@@ -291,8 +291,16 @@ class SeerConnect:  # pylint: disable=too-many-public-methods
     def get_study_ids_from_names_dataframe(self, study_names, party_id=None):
         if isinstance(study_names, str):
             study_names = [study_names]
-        studies = self.get_studies_dataframe(party_id=party_id)
-        return studies[studies['name'].isin(study_names)][['name', 'id']].reset_index(drop=True)
+
+        studies = pd.concat([
+            self.get_studies_dataframe(search_term=study_name, party_id=party_id) \
+                for study_name in study_names
+        ], join='outer')
+
+        if studies.empty:
+            return studies
+
+        return studies[['name', 'id']].reset_index(drop=True)
 
     def get_study_ids_from_names(self, study_names, party_id=None):
         return self.get_study_ids_from_names_dataframe(study_names, party_id)['id'].tolist()


### PR DESCRIPTION
Previously the entire dataset was downloaded and filtered
locally in the DataFrame. This approach runs one query per
study ID and concatenates the resulting DataFrames. This
should perform faster in most cases