### PR TITLE
Pagination for diary labels

### DIFF
--- a/Examples/download_diary_seizures.py
+++ b/Examples/download_diary_seizures.py
@@ -6,12 +6,17 @@ patients = seer_client.get_patients_dataframe() #party_id can be blank to return
 for n in range(len(patients)):
 
     patient_id = patients.loc[n]['id']
-    diary_df = seer_client.get_diary_labels_dataframe(patient_id)
-    if 'labelType' in diary_df.columns and not diary_df.loc[diary_df['labelType'] == 'seizure'].empty:
-        nEvents = diary_df.loc[diary_df['labelType'] == 'seizure'].iloc[0]['numberOfLabels']
-        if nEvents >= 10:
-            events = diary_df.loc[diary_df['labelType'] == 'seizure']
-            mdict = {'data': events}
-            savename = 'Patient '  + str(n)
-            print('saving ' + savename + '...')
-            events.to_excel(savename + '.xlsx')
+    patient_email = patients.loc[n]['user.email']
+    
+    if patient_email == 'pip@seermedical.com':
+        print(patient_email)
+        diary_df = seer_client.get_diary_labels_dataframe(patient_id)
+        
+#        if 'labelType' in diary_df.columns and not diary_df.loc[diary_df['labelType'] == 'seizure'].empty:
+#            nEvents = diary_df.loc[diary_df['labelType'] == 'seizure'].iloc[0]['numberOfLabels']
+#            if nEvents >= 10:
+#                events = diary_df.loc[diary_df['labelType'] == 'seizure']
+#                mdict = {'data': events}
+#                savename = 'Patient '  + str(n)
+#                print('saving ' + savename + '...')
+#                events.to_excel(savename + '.xlsx')

--- a/Examples/download_diary_seizures.py
+++ b/Examples/download_diary_seizures.py
@@ -15,9 +15,9 @@ for patient_id in patient_ids:
     diary_df = seer_client.get_diary_labels_dataframe(patient_id)
 
 #    Limit label groups to people with an epilepsy diary (where the default labelType is seizure)
-    if diary_df is not None and \
-        'labelType' in diary_df.columns \
-            and not diary_df.loc[diary_df['labelType'] == 'seizure'].empty:
+    if (diary_df is not None
+        and 'labelType' in diary_df.columns
+            and not diary_df.loc[diary_df['labelType'] == 'seizure'].empty):
 
         n_events = diary_df.loc[diary_df['labelType']
                                 == 'seizure'].iloc[0]['numberOfLabels']

--- a/Examples/download_diary_seizures.py
+++ b/Examples/download_diary_seizures.py
@@ -1,22 +1,28 @@
+# Example code to download all diary data for patients with N_EVENTS or more events recorded
+
 import seerpy
+
+N_EVENTS = 10
 
 seer_client = seerpy.SeerConnect()
 
 patients = seer_client.get_patients_dataframe() #party_id can be blank to return all results
+
 for n in range(len(patients)):
 
     patient_id = patients.loc[n]['id']
-    patient_email = patients.loc[n]['user.email']
     
-    if patient_email == 'pip@seermedical.com':
-        print(patient_email)
-        diary_df = seer_client.get_diary_labels_dataframe(patient_id)
+    diary_df = seer_client.get_diary_labels_dataframe(patient_id)
+    
+#    Limit label groups to people with an epilepsy diary (where the default labelType is seizure)
+    if 'labelType' in diary_df.columns and not diary_df.loc[diary_df['labelType'] == 'seizure'].empty:
         
-#        if 'labelType' in diary_df.columns and not diary_df.loc[diary_df['labelType'] == 'seizure'].empty:
-#            nEvents = diary_df.loc[diary_df['labelType'] == 'seizure'].iloc[0]['numberOfLabels']
-#            if nEvents >= 10:
-#                events = diary_df.loc[diary_df['labelType'] == 'seizure']
-#                mdict = {'data': events}
-#                savename = 'Patient '  + str(n)
-#                print('saving ' + savename + '...')
-#                events.to_excel(savename + '.xlsx')
+        nEvents = diary_df.loc[diary_df['labelType'] == 'seizure'].iloc[0]['numberOfLabels']
+        
+        if nEvents >= N_EVENTS:
+#            only save the events of interest
+            events = diary_df.loc[diary_df['labelType'] == 'seizure']
+            mdict = {'data': events}
+            savename = 'Patient '  + str(n)
+            print('saving ' + savename + '...')
+            events.to_excel(savename + '.xlsx')

--- a/Examples/download_diary_seizures.py
+++ b/Examples/download_diary_seizures.py
@@ -6,23 +6,26 @@ N_EVENTS = 10
 
 seer_client = seerpy.SeerConnect()
 
-patients = seer_client.get_patients_dataframe() #party_id can be blank to return all results
+# party_id can be blank to return all results
+patients = seer_client.get_patients_dataframe()
+patient_ids = patients['id']
 
-for n in range(len(patients)):
+for patient_id in patient_ids:
 
-    patient_id = patients.loc[n]['id']
-    
     diary_df = seer_client.get_diary_labels_dataframe(patient_id)
-    
+
 #    Limit label groups to people with an epilepsy diary (where the default labelType is seizure)
-    if 'labelType' in diary_df.columns and not diary_df.loc[diary_df['labelType'] == 'seizure'].empty:
-        
-        nEvents = diary_df.loc[diary_df['labelType'] == 'seizure'].iloc[0]['numberOfLabels']
-        
-        if nEvents >= N_EVENTS:
-#            only save the events of interest
+    if diary_df is not None and \
+        'labelType' in diary_df.columns \
+            and not diary_df.loc[diary_df['labelType'] == 'seizure'].empty:
+
+        n_events = diary_df.loc[diary_df['labelType']
+                                == 'seizure'].iloc[0]['numberOfLabels']
+
+        if n_events >= N_EVENTS:
+            #            only save the events of interest
             events = diary_df.loc[diary_df['labelType'] == 'seizure']
             mdict = {'data': events}
-            savename = 'Patient '  + str(n)
+            savename = 'P_' + patient_id.replace('-', '')
             print('saving ' + savename + '...')
             events.to_excel(savename + '.xlsx')

--- a/Examples/download_diary_seizures.py
+++ b/Examples/download_diary_seizures.py
@@ -15,8 +15,7 @@ for patient_id in patient_ids:
     diary_df = seer_client.get_diary_labels_dataframe(patient_id)
 
 #    Limit label groups to people with an epilepsy diary (where the default labelType is seizure)
-    if (diary_df is not None
-        and 'labelType' in diary_df.columns
+    if (diary_df is not None and 'labelType' in diary_df.columns
             and not diary_df.loc[diary_df['labelType'] == 'seizure'].empty):
 
         n_events = diary_df.loc[diary_df['labelType']

--- a/Examples/download_diary_seizures.py
+++ b/Examples/download_diary_seizures.py
@@ -1,0 +1,17 @@
+import seerpy
+
+seer_client = seerpy.SeerConnect()
+
+patients = seer_client.get_patients_dataframe() #party_id can be blank to return all results
+for n in range(len(patients)):
+
+    patient_id = patients.loc[n]['id']
+    diary_df = seer_client.get_diary_labels_dataframe(patient_id)
+    if 'labelType' in diary_df.columns and not diary_df.loc[diary_df['labelType'] == 'seizure'].empty:
+        nEvents = diary_df.loc[diary_df['labelType'] == 'seizure'].iloc[0]['numberOfLabels']
+        if nEvents >= 10:
+            events = diary_df.loc[diary_df['labelType'] == 'seizure']
+            mdict = {'data': events}
+            savename = 'Patient '  + str(n)
+            print('saving ' + savename + '...')
+            events.to_excel(savename + '.xlsx')

--- a/seerpy/graphql.py
+++ b/seerpy/graphql.py
@@ -302,7 +302,7 @@ def get_patients_query_string():
         }"""
 
 
-def get_diary_labels_query_string(patient_id):
+def get_diary_labels_query_string(patient_id, limit, offset):
     return """
         query {
             patient (id: "%s") {
@@ -314,7 +314,8 @@ def get_diary_labels_query_string(patient_id):
                         labelType
                         labelSourceType
                         name
-                        labels {
+                        numberOfLabels
+                        labels(limit: %.0f, offset: %.0f) {
                             id
                             startTime
                             timezone
@@ -336,7 +337,7 @@ def get_diary_labels_query_string(patient_id):
                     }
                 }
             }
-        }""" % patient_id
+        }""" % (patient_id, limit, offset)
 
 
 def get_documents_for_study_ids_paged_query_string(study_ids):

--- a/seerpy/seerpy.py
+++ b/seerpy/seerpy.py
@@ -524,7 +524,7 @@ class SeerConnect:  # pylint: disable=too-many-public-methods
     def get_diary_labels(self, patient_id, offset=0, limit=100):
         label_results = None
         # set true if we need to fetch labels
-        query_flag = 1
+        query_flag = True
 
         while True:
             if not query_flag:
@@ -534,7 +534,7 @@ class SeerConnect:  # pylint: disable=too-many-public-methods
             response = self.execute_query(query_string)['patient']['diary']
             label_groups = response['labelGroups']
 
-            query_flag = None
+            query_flag = False
             for idx, group in enumerate(label_groups):
                 labels = group['labels']
 
@@ -543,7 +543,7 @@ class SeerConnect:  # pylint: disable=too-many-public-methods
 
                 # we need to fetch more labels
                 if len(labels) >= limit:
-                    query_flag = 1
+                    query_flag = True
 
                 if label_results is None:
                     label_results = response


### PR DESCRIPTION
This PR *elegantly* adds a limit and offset to the `get_diary_labels` so that all available labels are returned (previously this was capped to 100). 

Pair coding with @dominique-eden :)

## File changes
- Added a new example code to download and save labels from patient seizure diaries
- Included `limit` and `offset` in the `get_diary_labels_query_string` query as well as the `numberOfLabels` field (a nice sanity check to make sure you are getting all the available labels)
- Update `get_diary_labels` to loop through and request all labels for all label groups
- Also my linter seems to have made some random whitespace changes around about (sorry).