### PR TITLE
Example.ipynb: replace add_labels

### DIFF
--- a/Examples/Example.ipynb
+++ b/Examples/Example.ipynb
@@ -1639,7 +1639,7 @@
     "study_start = datetime.datetime.fromtimestamp(data['time'].iloc[0]/1000.0)\n",
     "labels['timezone'] = int(int(pytz.timezone('Australia/Melbourne').localize(study_start).strftime('%z'))/100)\n",
     "\n",
-    "response = client.add_labels(label_group_id, labels)\n",
+    "response = client.add_labels_batched(label_group_id, labels)\n",
     "response"
    ]
   },


### PR DESCRIPTION
Replace `add_labels()` with `add_labels_batched()` in `Example.ipynb` to avoid a timeout for those that may have access to a lot of data.