### PR TITLE
Pin GraphQL Core Dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,10 @@
-git+https://github.com/graphql-python/gql.git@609b3fc8c0b439a5b8af656a740f7668bad0224b
+gql
 requests
 matplotlib
 numpy
 pandas
 scipy
+# TODO: graphql-core 3.0.0 has a problem as at 02/12/2019
+# revisit in the future, we may be able to remove the restriction
+graphql-core<3.0.0
 -e .

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-gql
+git+https://github.com/graphql-python/gql.git@609b3fc8c0b439a5b8af656a740f7668bad0224b
 requests
 matplotlib
 numpy


### PR DESCRIPTION
GQL the GraphQL Implementation used within seer-py, was broken by an upgrade to the graphql-core package. This broke the interface of gql that seerpy depends on. Unfortunately `gql` is no longer mainted actively and the most active maintainer doesn't have permission to publish to PyPI, thus why this depends on the `gql` github project itself, which was fixed in https://github.com/graphql-python/gql/pull/52.

https://github.com/graphql-python/gql/issues/51