### PR TITLE
Add Fitbit data access functions

### DIFF
--- a/Examples/fitbit_activity.py
+++ b/Examples/fitbit_activity.py
@@ -1,0 +1,20 @@
+import seerpy
+
+seer_client = seerpy.SeerConnect()
+
+fitbit_step_name = 'Fitbit Activity Steps'
+fitbit_heart_rate_name = 'Fitbit Heart Rate'
+
+patients = seer_client.get_patients_dataframe()
+patient_ids = patients['id']
+
+for idx, patient_id in enumerate(patient_ids):
+
+    patient_email = patients.loc[idx]['user.email']
+    
+#    test on i.e. Pip's data
+    if patient_email == 'pip@seermedical.com':
+        
+#        Get available channel groups
+        diary_data_channels = seer_client.get_diary_channel_groups_dataframe(patient_id)
+        data = seer_client.get_diary_data(diary_data_channels['dataChunks.url'][0])

--- a/Examples/fitbit_activity.py
+++ b/Examples/fitbit_activity.py
@@ -1,4 +1,7 @@
 import seerpy
+from datetime import datetime
+from datetime import timedelta
+from dateutil import tz
 
 seer_client = seerpy.SeerConnect()
 
@@ -8,13 +11,27 @@ fitbit_heart_rate_name = 'Fitbit Heart Rate'
 patients = seer_client.get_patients_dataframe()
 patient_ids = patients['id']
 
+# Get the previous week worth of data
+today = datetime.utcnow().date()
+end_time = datetime(today.year, today.month, today.day, tzinfo=tz.tzutc())
+start_time = end_time - timedelta(days=7)
+
+# time stamps are in ms
+from_time = start_time.timestamp() * 1000
+to_time = end_time.timestamp() * 1000
+
 for idx, patient_id in enumerate(patient_ids):
 
     patient_email = patients.loc[idx]['user.email']
     
-#    test on i.e. Pip's data
-    if patient_email == 'pip@seermedical.com':
+#    get data for i.e. patient email
+    if patient_email == 'EMAIL':
         
-#        Get available channel groups
-        diary_data_channels = seer_client.get_diary_channel_groups_dataframe(patient_id)
-        data = seer_client.get_diary_data(diary_data_channels['dataChunks.url'][0])
+#        Get available channel groups        
+        diary_data_channels = seer_client.get_diary_channel_groups_dataframe(patient_id, from_time, to_time)
+        
+#        can change to get heart rate or step count here
+        segments = diary_data_channels.loc[diary_data_channels['name'] == fitbit_heart_rate_name]
+        segments = segments.reset_index(drop=True)
+        
+        data, group_names, start_times = seer_client.get_diary_fitbit_data(segments)

--- a/Examples/fitbit_sleep.py
+++ b/Examples/fitbit_sleep.py
@@ -1,4 +1,7 @@
 import seerpy
+from datetime import datetime
+from datetime import timedelta
+from dateutil import tz
 
 seer_client = seerpy.SeerConnect()
 
@@ -7,13 +10,22 @@ fitbit_sleep_name = 'Fitbit Sleep Labels'
 
 patients = seer_client.get_patients_dataframe()
 
+# Get the previous week worth of data
+today = datetime.utcnow().date()
+end_time = datetime(today.year, today.month, today.day, tzinfo=tz.tzutc())
+start_time = end_time - timedelta(days=7)
+
+# time stamps are in ms
+from_time = start_time.timestamp() * 1000
+to_time = end_time.timestamp() * 1000
+
 for n in range(len(patients)):
 
     patient_id = patients.loc[n]['id']
     patient_email = patients.loc[n]['user.email']
     
-#    test on i.e. Pip's data
-    if patient_email == 'pip@seermedical.com':
+#    get data for i.e. patient email
+    if patient_email == 'EMAIL':
         
 #        Get available label groups
         diary_data_groups = seer_client.get_diary_data_groups_dataframe(patient_id)
@@ -21,7 +33,7 @@ for n in range(len(patients)):
         for group in range(len(diary_data_groups)):
             group_name = diary_data_groups.loc[group]['name']
     
-#            get the label group for fitbit sleep labels
+    #            get the label group for fitbit sleep labels
             if  group_name == fitbit_sleep_name:
                 group_id = diary_data_groups.loc[group]['id']
-                sleep_labels = seer_client.get_diary_data_labels_dataframe(patient_id, group_id)
+                sleep_labels = seer_client.get_diary_data_labels_dataframe(patient_id, group_id, from_time, to_time)

--- a/Examples/fitbit_sleep.py
+++ b/Examples/fitbit_sleep.py
@@ -1,0 +1,27 @@
+import seerpy
+
+seer_client = seerpy.SeerConnect()
+
+# Access to Fitbit labels is by knowing the name of the corret label group
+fitbit_sleep_name = 'Fitbit Sleep Labels'
+
+patients = seer_client.get_patients_dataframe()
+
+for n in range(len(patients)):
+
+    patient_id = patients.loc[n]['id']
+    patient_email = patients.loc[n]['user.email']
+    
+#    test on i.e. Pip's data
+    if patient_email == 'pip@seermedical.com':
+        
+#        Get available label groups
+        diary_study_groups = seer_client.get_diary_study_label_groups_dataframe(patient_id)
+        
+        for group in range(len(diary_study_groups)):
+            group_name = diary_study_groups.loc[group]['name']
+    
+#            get the label group for fitbit sleep labels
+            if  group_name == fitbit_sleep_name:
+                label_group_id = diary_study_groups.loc[group]['id']
+                sleep_labels = seer_client.get_diary_study_labels_dataframe(patient_id, label_group_id)

--- a/Examples/fitbit_sleep.py
+++ b/Examples/fitbit_sleep.py
@@ -16,12 +16,12 @@ for n in range(len(patients)):
     if patient_email == 'pip@seermedical.com':
         
 #        Get available label groups
-        diary_study_groups = seer_client.get_diary_study_label_groups_dataframe(patient_id)
+        diary_data_groups = seer_client.get_diary_data_groups_dataframe(patient_id)
         
-        for group in range(len(diary_study_groups)):
-            group_name = diary_study_groups.loc[group]['name']
+        for group in range(len(diary_data_groups)):
+            group_name = diary_data_groups.loc[group]['name']
     
 #            get the label group for fitbit sleep labels
             if  group_name == fitbit_sleep_name:
-                label_group_id = diary_study_groups.loc[group]['id']
-                sleep_labels = seer_client.get_diary_study_labels_dataframe(patient_id, label_group_id)
+                group_id = diary_data_groups.loc[group]['id']
+                sleep_labels = seer_client.get_diary_data_labels_dataframe(patient_id, group_id)

--- a/seerpy/graphql.py
+++ b/seerpy/graphql.py
@@ -490,7 +490,7 @@ def get_labels_for_diary_study_query_string(patient_id, label_group_id,  # pylin
                 diaryStudy {
                     labelGroup (labelGroupId: "%s") {
                         id
-                        labels (limit: %.0f, offset: %.0f, fromTime: %.0f, toTime: %.0f) {
+                        labels (limit: %.0f, offset: %.0f, from: %.0f, to: %.0f) {
                             id
                             startTime
                             timezone
@@ -505,3 +505,31 @@ def get_labels_for_diary_study_query_string(patient_id, label_group_id,  # pylin
                 }
             }
         }""" % (patient_id, label_group_id, limit, offset, from_time, to_time)
+
+
+def get_diary_study_channel_groups_query_string(patient_id, from_time, to_time):
+
+    return """
+        query {
+            patient(id: "%s") {
+                id
+                diaryStudy {
+                    channelGroups {
+                        id
+                        name
+                        recordsPerChunk
+                        sampleEncoding
+                        compression
+                        segments (fromTime: %.0f, toTime: %.0f) {
+                            id
+                            startTime
+                            duration
+                            timezone
+                            dataChunks {
+                                url
+                            }
+                        }
+                    }
+                }
+            }
+        }""" % (patient_id, from_time, to_time)

--- a/seerpy/graphql.py
+++ b/seerpy/graphql.py
@@ -521,7 +521,7 @@ def get_diary_study_channel_groups_query_string(patient_id, from_time, to_time):
                         recordsPerChunk
                         sampleEncoding
                         compression
-                        segments (fromTime: %.0f, toTime: %.0f) {
+                        segments (ranges: [{ from: %.0f, to: %.0f }]) {
                             id
                             startTime
                             duration

--- a/seerpy/graphql.py
+++ b/seerpy/graphql.py
@@ -24,9 +24,9 @@ def get_string_from_list_of_dicts(list_of_dicts):
                     labels_string += (get_json_list(d[k]) + ",")
             else:
                 labels_string += str(d[k]) + ','
-        labels_string = labels_string[:-1] # remove last comma
+        labels_string = labels_string[:-1]  # remove last comma
         labels_string += '},'
-    labels_string = labels_string[:-1] # remove last comma
+    labels_string = labels_string[:-1]  # remove last comma
     return labels_string
 
 
@@ -120,7 +120,7 @@ def get_labels_query_string(study_id, label_group_id,  # pylint:disable=too-many
 
 
 def get_labels_string_query_string(study_id, label_group_id,  # pylint:disable=too-many-arguments
-                            from_time, to_time):
+                                   from_time, to_time):
     return """
         query {
             study (id: "%s") {
@@ -187,6 +187,7 @@ def get_segment_urls_query_string(segment_ids):
                 baseDataChunkUrl
             }
         }""" % segment_ids_string
+
 
 def get_data_chunk_urls_query_string(data_chunks, s3_urls=True):
     chunk_keys = get_string_from_list_of_dicts(data_chunks)
@@ -403,6 +404,7 @@ def get_add_document_mutation_string(study_id, document):
             }
         }""" % (study_id, document)
 
+
 def get_confirm_document_mutation_string(study_id, document_id):
     return """
         mutation {
@@ -415,6 +417,7 @@ def get_confirm_document_mutation_string(study_id, document_id):
                 downloadFileUrl
             }
         }""" % (study_id, document_id)
+
 
 def get_bookings_query_string(organisation_id, start_time, end_time):
     return """query {
@@ -460,3 +463,46 @@ def get_bookings_query_string(organisation_id, start_time, end_time):
             }""" % (organisation_id, start_time, end_time)
 
 
+def get_diary_study_label_groups_string(patient_id, limit, offset):
+
+    return """
+        query {
+            patient (id: "%s") {
+                id
+                diaryStudy {
+                    labelGroups(limit: %.0f, offset: %.0f) {
+                        id
+                        name
+                        numberOfLabels
+                    }
+                }
+            }
+        }
+    """ % (patient_id, limit, offset)
+
+
+def get_labels_for_diary_study_query_string(patient_id, label_group_id,  # pylint:disable=too-many-arguments
+                                            from_time, to_time, limit, offset):
+    return """
+        query {
+            patient (id: "%s") {
+                id
+                diaryStudy {
+                    labelGroup (labelGroupId: "%s") {
+                        id
+                        labels (limit: %.0f, offset: %.0f, fromTime: %.0f, toTime: %.0f) {
+                            id
+                            startTime
+                            timezone
+                            duration
+                            tags {
+                                id
+                                tagType {
+                                    value
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }""" % (patient_id, label_group_id, limit, offset, from_time, to_time)

--- a/seerpy/graphql.py
+++ b/seerpy/graphql.py
@@ -496,7 +496,6 @@ def get_labels_for_diary_study_query_string(patient_id, label_group_id,  # pylin
                             timezone
                             duration
                             tags {
-                                id
                                 tagType {
                                     value
                                 }

--- a/seerpy/seerpy.py
+++ b/seerpy/seerpy.py
@@ -827,7 +827,7 @@ class SeerConnect:  # pylint: disable=too-many-public-methods
 
         data_list = []
         for idx, url in enumerate(segment_urls):
-            new_data = utils.get_diary_data(url)
+            new_data = utils.get_diary_fitbit_data(url)
             new_data['timestamp'] = new_data['timestamp'] + start_times[idx]
             new_data['name'] = group_names[idx]
             data_list.append(new_data)

--- a/seerpy/utils.py
+++ b/seerpy/utils.py
@@ -35,7 +35,8 @@ def download_channel_data(data_q, download_function):
         data = np.transpose(data, (0, 2, 1))
         data = data.reshape(-1, data.shape[2])
         if 'int' in data_type:
-            nan_mask = np.all(data == np.iinfo(np.dtype(data_type)).min, axis=1)
+            nan_mask = np.all(data == np.iinfo(
+                np.dtype(data_type)).min, axis=1)
             if nan_mask[-1]:
                 nan_mask_corrected = np.ones(nan_mask.shape, dtype=bool)
                 for i in range(len(nan_mask) - 1, -1, -1):
@@ -46,8 +47,9 @@ def download_channel_data(data_q, download_function):
                 data = data[nan_mask_corrected]
 
             # fill missing values with nans
-            data[np.all(data == np.iinfo(np.dtype(data_type)).min, axis=1), :] = np.nan
-        ## TODO: what happens for floats?
+            data[np.all(data == np.iinfo(
+                np.dtype(data_type)).min, axis=1), :] = np.nan
+        # TODO: what happens for floats?
         chan_min = meta_data['channelGroups.signalMin'].astype(np.float64)
         chan_max = meta_data['channelGroups.signalMax'].astype(np.float64)
         exponent = meta_data['channelGroups.exponent'].astype(np.float64)
@@ -70,7 +72,8 @@ def download_channel_data(data_q, download_function):
         data['id'] = study_id
         data['channelGroups.id'] = channel_groups_id
         data['segments.id'] = segments_id
-        data = data[['time', 'id', 'channelGroups.id', 'segments.id'] + channel_names]
+        data = data[['time', 'id', 'channelGroups.id',
+                     'segments.id'] + channel_names]
         return data
     except Exception as ex:
         print(ex)
@@ -102,16 +105,20 @@ def create_data_chunk_urls(metadata, segment_urls, from_time=0, to_time=9e12):
         seg_base_url = seg_base_urls.iloc[0]
 
         chunk_period = row['channelGroups.chunkPeriod']
-        num_chunks = int(np.ceil(row['segments.duration'] / chunk_period / 1000.))
+        num_chunks = int(
+            np.ceil(row['segments.duration'] / chunk_period / 1000.))
         start_time = row['segments.startTime']
 
         for i in range(num_chunks):
             chunk_start_time = chunk_period * 1000 * i + start_time
             next_chunk_start_time = chunk_period * 1000 * (i + 1) + start_time
             if (chunk_start_time <= to_time and next_chunk_start_time >= from_time):
-                data_chunk_name = str(i).zfill(len(chunk_pattern) - 4) + chunk_pattern[-4:]
-                data_chunk_url = seg_base_url.replace(chunk_pattern, data_chunk_name)
-                data_chunk = [row['segments.id'], data_chunk_url, chunk_start_time]
+                data_chunk_name = str(i).zfill(
+                    len(chunk_pattern) - 4) + chunk_pattern[-4:]
+                data_chunk_url = seg_base_url.replace(
+                    chunk_pattern, data_chunk_name)
+                data_chunk = [row['segments.id'],
+                              data_chunk_url, chunk_start_time]
                 data_chunks.append(data_chunk)
 
     return pd.DataFrame.from_records(data_chunks, columns=['segments.id', 'dataChunks.url',
@@ -175,7 +182,8 @@ def get_channel_data(all_data, segment_urls,  # pylint:disable=too-many-argument
                              'channelGroups.signalMin', 'channelGroups.signalMax',
                              'channelGroups.exponent']]
         metadata = metadata.drop_duplicates()
-        metadata = metadata.dropna(axis=0, how='any', subset=['dataChunks.url'])
+        metadata = metadata.dropna(
+            axis=0, how='any', subset=['dataChunks.url'])
         for i in range(len(metadata.index)):
             data_q.append([metadata.iloc[i], study_id, channel_groups_id, segment_id,
                            actual_channel_names])
@@ -189,7 +197,8 @@ def get_channel_data(all_data, segment_urls,  # pylint:disable=too-many-argument
             pool.close()
             pool.join()
         else:
-            data_list = [download_function(data_q_item) for data_q_item in data_q]
+            data_list = [download_function(data_q_item)
+                         for data_q_item in data_q]
 
     if data_list:
         # sort=False to silence deprecation warning. This comes into play when we are processing
@@ -263,7 +272,8 @@ def plot_eeg(x, y=None, pred=None, squeeze=5.0, scaling_factor=None):
     offsets = np.zeros((channels, 2), dtype=float)
     offsets[:, 1] = ticklocs
 
-    lines = LineCollection(segs, offsets=offsets, transOffset=None, linewidths=(0.5))
+    lines = LineCollection(segs, offsets=offsets,
+                           transOffset=None, linewidths=(0.5))
     ax2.add_collection(lines)
 
     if y is not None:
@@ -289,7 +299,8 @@ def butter_bandstop(lowcut, highcut, fs, order=5):
     nyq = 0.5 * fs
     low = lowcut / nyq
     high = highcut / nyq
-    sos = butter(order, [low, high], analog=False, btype='bandstop', output='sos')
+    sos = butter(order, [low, high], analog=False,
+                 btype='bandstop', output='sos')
     return sos
 
 
@@ -303,7 +314,8 @@ def butter_bandpass(lowcut, highcut, fs, order=5):
     nyq = 0.5 * fs
     low = lowcut / nyq
     high = highcut / nyq
-    sos = butter(order, [low, high], analog=False, btype='bandpass', output='sos')
+    sos = butter(order, [low, high], analog=False,
+                 btype='bandpass', output='sos')
     return sos
 
 
@@ -311,3 +323,12 @@ def butter_bandpass_filter(data, lowcut, highcut, fs, order=5):
     sos = butter_bandpass(lowcut, highcut, fs, order=order)
     y = sosfilt(sos, data)
     return y
+
+
+def get_diary_data(data_url):
+    raw_data = requests.get(data_url)
+    data = raw_data.content
+    # print(data)
+
+    # data = gzip.decompress(data)
+    return data

--- a/seerpy/utils.py
+++ b/seerpy/utils.py
@@ -328,10 +328,14 @@ def butter_bandpass_filter(data, lowcut, highcut, fs, order=5):
 def get_diary_data(data_url):
     raw_data = requests.get(data_url)
     data = raw_data.content
-    # print(data)
 
-    # data = gzip.decompress(data)
-    data_type = 'float'
+    # Hardcoded here as in the database the sample encoding for Fitbit channel groups
+    # is saved as 'int16' but float32 is correct
+    data_type = 'float32'
     data = np.frombuffer(data, dtype=np.dtype(data_type))
     data = data.astype(np.float32)
+
+    # Fitbit data is currently always in alternating digits (time stamp, value)
+    data = data.reshape(int(len(data)/2), 2)
+    data = pd.DataFrame(data=data, columns=['timestamp', 'value'])
     return data

--- a/seerpy/utils.py
+++ b/seerpy/utils.py
@@ -331,4 +331,7 @@ def get_diary_data(data_url):
     # print(data)
 
     # data = gzip.decompress(data)
+    data_type = 'float'
+    data = np.frombuffer(data, dtype=np.dtype(data_type))
+    data = data.astype(np.float32)
     return data

--- a/seerpy/utils.py
+++ b/seerpy/utils.py
@@ -325,7 +325,7 @@ def butter_bandpass_filter(data, lowcut, highcut, fs, order=5):
     return y
 
 
-def get_diary_data(data_url):
+def get_diary_fitbit_data(data_url):
     raw_data = requests.get(data_url)
     data = raw_data.content
 


### PR DESCRIPTION
This PR adds functions to access Fitbit data given patient ID. The Fitbit data is stored in a database table and S3 buckets. All Fitbit data is stored under the `diaryStudy` for a patient and the data structure closely mimics studies:
- Fitbit sleep labels: stored as labels in a `labelGroup` named "Fitbit Sleep Labels"
- Heart rate and step count: stored in S3 buckets accessed via URLs. These data are saved in two channel groups ('Fitbit Activity Steps' and 'Fitbit Heart Rate') divided into segments and there is one URL per segment.

### New functions (and associated queries)

Usage examples are provided in the two example scripts.

- `get_diary_data_groups_dataframe`: gets label groups for a patient's `diaryStudy`
- `get_diary_data_labels_dataframe`: gets labels for a diary study label group id (with optional start and end time)
- `get_diary_channel_groups_dataframe`: get available channel group segments for `diaryStudy`
- `get_diary_fitbit_data`: get Fitbit data for a list of segments (obtained from the previous function)
- `utils.get_diary_fitbit_data`: downloads the raw data from provided URL and decodes according to known (hardcoded) parameters of how Fitbit data is stored