### PR TITLE
Support different API endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,21 @@
 # seer-py
+
 Python SDK for the Seer data platform, which handles authenticating a user, downloading channel data, and uploading labels/annotations.
 
 ## Install
+
 To install, simply clone or download this repository, then type `pip install .` which will install all the dependencies.
 
 ### Epilepsy Ecosystem Data
+
 For users attempting to download data for the [Epilepsy Ecosystem](https://www.epilepsyecosystem.org/howitworks/), please download the [latest release](https://github.com/seermedical/seer-py/releases/latest) instead of cloning the repository or downloading the master branch. Then open the script `ContestDataDownloader.py` in `Examples` and it will guide you through the download process (you will need to change a few things in this script including the path to download the data to).
 
 ## Requirements
+
 This library currently requires Python 3, and it if you don't currently have a Python 3 installation, we recommend you use the Anaconda distribution for its simplicity, support, stability and extensibility. It can be downloaded here: https://www.anaconda.com/download
 
 The install instructions above will install all the required dependencies, however, if you wish to install them yourself, here's what you'll need:
+
 - [`gql`](https://github.com/graphql-python/gql): a GraphQL python library is required to query the Seer platform. To install, simply run: `pip install gql`
 - Pandas, numpy, and matplotlib are also required. Some of these installs can be tricky, so Anaconda is recommended, however, they can be installed separately. Please see these guides for more detailed information:
   - https://scipy.org/install.html
@@ -20,12 +25,25 @@ The install instructions above will install all the required dependencies, howev
 To run the Jupyter notebook example (optional, included in Anaconda): `pip install notebook`
 
 ## Getting Started
-Check out the [Example](Examples/Example.ipynb) for a step-by-step example of how to use the SDK to access data on the Seer platform. 
+
+Check out the [Example](Examples/Example.ipynb) for a step-by-step example of how to use the SDK to access data on the Seer platform.
 
 To start a Jupyter notebook, run `jupyter notebook` in a command/bash window. Further instructions on Jupyter can be found here: https://github.com/jupyter/notebook
+
+## Running with other API endpoints
+
+To run seer-py against other environments (for instance against a development API server), perform the following steps:
+
+1. Run the `seer-api` server following the relevant documentation in the API repository
+2. Run a `seer-graphiql` server (which includes the required proxies), ensuring that `HTTPS` is set to `OFF` in the startup script,
+3. Call `SeerConnect` with the alternative endpoint, and setting `dev` to `True`. For example:
+
+```python
+client = SeerConnect(api_url='http://localhost:3090/api/development', dev=True)
+```
 
 ## Troubleshooting
 
 ### Downloading hangs on Windows
-There is a known issue with using python's multiprocessing module on Windows with spyder. The function `getLinks` uses `multiprocessing.Pool` to run multiple downloads simultaneously, which can cause the process to run indefinitely. The workaround for this is to ensure that the current working directory is set to the directory containing your script. Running the script from a command window will also solve this problem. Alternatively, setting `threads=1` in the `getLinks` function will stop in from using `multiprocessing` altogether.
 
+There is a known issue with using python's multiprocessing module on Windows with spyder. The function `getLinks` uses `multiprocessing.Pool` to run multiple downloads simultaneously, which can cause the process to run indefinitely. The workaround for this is to ensure that the current working directory is set to the directory containing your script. Running the script from a command window will also solve this problem. Alternatively, setting `threads=1` in the `getLinks` function will stop in from using `multiprocessing` altogether.

--- a/seerpy/auth.py
+++ b/seerpy/auth.py
@@ -9,9 +9,10 @@ import requests
 
 class SeerAuth:
 
-    def __init__(self, api_url, email=None, password=None):
+    def __init__(self, api_url, email=None, password=None, dev=False):
         self.api_url = api_url
         self.cookie = None
+        self.dev = dev
 
         self.read_cookie()
         if self.verify_login() == 200:
@@ -48,7 +49,16 @@ class SeerAuth:
         print("login status_code", response.status_code)
         if (response.status_code == requests.codes.ok  # pylint: disable=maybe-no-member
                 and response.cookies):
-            self.cookie = {'seer.sid' : response.cookies['seer.sid']}
+
+            seer_sid = response.cookies.get('seer.sid', False)
+            seerdev_sid = response.cookies.get('seerdev.sid', False)
+
+            self.cookie = {}
+            if seer_sid:
+                self.cookie['seer.sid'] = seer_sid
+            if seerdev_sid:
+                self.cookie['seerdev.sid'] = seerdev_sid
+
         else:
             self.cookie = None
 
@@ -59,7 +69,8 @@ class SeerAuth:
         verify_url = self.api_url + '/auth/verify'
         response = requests.get(url=verify_url, cookies=self.cookie)
         if response.status_code != requests.codes.ok:  # pylint: disable=maybe-no-member
-            print("api verify call returned", response.status_code, "status code")
+            print("api verify call returned",
+                  response.status_code, "status code")
             return 401
 
         json_response = response.json()
@@ -82,10 +93,13 @@ class SeerAuth:
             self.email = input('Email Address: ')
             self.password = getpass.getpass('Password: ')
 
+    def get_cookie_path(self):
+        return '/.seerpy/cookie-dev' if self.dev else '/.seerpy/cookie'
+
     def write_cookie(self):
         try:
             home = os.path.expanduser('~')
-            cookie_file = home + '/.seerpy/cookie'
+            cookie_file = home + self.get_cookie_path()
             if not os.path.isdir(home + '/.seerpy'):
                 os.mkdir(home + '/.seerpy')
             with open(cookie_file, 'w') as f:
@@ -95,14 +109,14 @@ class SeerAuth:
 
     def read_cookie(self):
         home = os.path.expanduser('~')
-        cookie_file = home + '/.seerpy/cookie'
+        cookie_file = home + self.get_cookie_path()
         if os.path.isfile(cookie_file):
             with open(cookie_file, 'r') as f:
                 self.cookie = json.loads(f.read().strip())
 
     def destroy_cookie(self):
         home = os.path.expanduser('~')
-        cookie_file = home + '/.seerpy/cookie'
+        cookie_file = home + self.get_cookie_path()
         if os.path.isfile(cookie_file):
             os.remove(cookie_file)
         self.cookie = None

--- a/seerpy/auth.py
+++ b/seerpy/auth.py
@@ -7,6 +7,10 @@ import json
 import requests
 
 
+COOKIE_KEY_PROD = 'seer.sid'
+COOKIE_KEY_DEV = 'seerdev.sid'
+
+
 class SeerAuth:
 
     def __init__(self, api_url, email=None, password=None, dev=False):
@@ -50,14 +54,14 @@ class SeerAuth:
         if (response.status_code == requests.codes.ok  # pylint: disable=maybe-no-member
                 and response.cookies):
 
-            seer_sid = response.cookies.get('seer.sid', False)
-            seerdev_sid = response.cookies.get('seerdev.sid', False)
+            seer_sid = response.cookies.get(COOKIE_KEY_PROD, False)
+            seerdev_sid = response.cookies.get(COOKIE_KEY_DEV, False)
 
             self.cookie = {}
             if seer_sid:
-                self.cookie['seer.sid'] = seer_sid
-            if seerdev_sid:
-                self.cookie['seerdev.sid'] = seerdev_sid
+                self.cookie[COOKIE_KEY_PROD] = seer_sid
+            elif seerdev_sid:
+                self.cookie[COOKIE_KEY_DEV] = seerdev_sid
 
         else:
             self.cookie = None

--- a/seerpy/auth.py
+++ b/seerpy/auth.py
@@ -42,7 +42,7 @@ class SeerAuth:
                 raise InterruptedError('Authentication Failed')
 
     def login(self):
-        login_url = self.api_url + '/api/auth/login'
+        login_url = self.api_url + '/auth/login'
         body = {'email': self.email, 'password': self.password}
         response = requests.post(url=login_url, data=body)
         print("login status_code", response.status_code)
@@ -56,7 +56,7 @@ class SeerAuth:
         if self.cookie is None:
             return 401
 
-        verify_url = self.api_url + '/api/auth/verify'
+        verify_url = self.api_url + '/auth/verify'
         response = requests.get(url=verify_url, cookies=self.cookie)
         if response.status_code != requests.codes.ok:  # pylint: disable=maybe-no-member
             print("api verify call returned", response.status_code, "status code")

--- a/seerpy/seerpy.py
+++ b/seerpy/seerpy.py
@@ -47,8 +47,13 @@ class SeerConnect:  # pylint: disable=too-many-public-methods
     def login(self, email=None, password=None):
         self.seer_auth = SeerAuth(self.api_url, email, password, self.dev)
         cookie = self.seer_auth.cookie
-        header = {'Cookie': list(cookie.keys())[
-            0] + '=' + cookie['seerdev.sid'] if self.dev else cookie['seer.sid']}
+
+        header =  {}
+
+        if self.dev:
+            header['Cookie'] = f'seerdev.sid={cookie["seerdev.sid"]}'
+        else:
+            header['Cookie'] = f'seer.sid={cookie["seer.sid"]}'
 
         def graphql_client(party_id=None):
             url_suffix = '?partyId=' + party_id if party_id else ''

--- a/seerpy/seerpy.py
+++ b/seerpy/seerpy.py
@@ -17,7 +17,7 @@ from . import graphql
 
 class SeerConnect:  # pylint: disable=too-many-public-methods
 
-    def __init__(self, api_url='https://api.seermedical.com', email=None, password=None):
+    def __init__(self, api_url='https://api.seermedical.com/api', email=None, password=None):
         """Creates a GraphQL client able to interact with
             the Seer database, handling login and authorisation
         Parameters
@@ -49,7 +49,7 @@ class SeerConnect:  # pylint: disable=too-many-public-methods
 
         def graphql_client(party_id=None):
             url_suffix = '?partyId=' + party_id if party_id else ''
-            url = self.api_url + '/api/graphql' + url_suffix
+            url = self.api_url + '/graphql' + url_suffix
             return GQLClient(
                 transport=RequestsHTTPTransport(
                     url=url,

--- a/seerpy/seerpy.py
+++ b/seerpy/seerpy.py
@@ -10,7 +10,7 @@ import pandas as pd
 from pandas.io.json import json_normalize
 import requests
 
-from .auth import SeerAuth
+from .auth import SeerAuth, COOKIE_KEY_DEV, COOKIE_KEY_PROD
 from . import utils
 from . import graphql
 
@@ -48,12 +48,10 @@ class SeerConnect:  # pylint: disable=too-many-public-methods
         self.seer_auth = SeerAuth(self.api_url, email, password, self.dev)
         cookie = self.seer_auth.cookie
 
-        header =  {}
-
-        if self.dev:
-            header['Cookie'] = f'seerdev.sid={cookie["seerdev.sid"]}'
-        else:
-            header['Cookie'] = f'seer.sid={cookie["seer.sid"]}'
+        key = COOKIE_KEY_DEV if self.dev else COOKIE_KEY_PROD
+        header =  {
+            'Cookie': f'{key}={cookie[key]}'
+        }
 
         def graphql_client(party_id=None):
             url_suffix = '?partyId=' + party_id if party_id else ''

--- a/seerpy/seerpy.py
+++ b/seerpy/seerpy.py
@@ -17,7 +17,7 @@ from . import graphql
 
 class SeerConnect:  # pylint: disable=too-many-public-methods
 
-    def __init__(self, api_url='https://api.seermedical.com/api', email=None, password=None):
+    def __init__(self, api_url='https://api.seermedical.com/api', email=None, password=None, dev=False):
         """Creates a GraphQL client able to interact with
             the Seer database, handling login and authorisation
         Parameters
@@ -36,6 +36,8 @@ class SeerConnect:  # pylint: disable=too-many-public-methods
         """
 
         self.api_url = api_url
+        self.dev = dev
+
         self.login(email, password)
 
         self.last_query_time = time.time()
@@ -43,9 +45,10 @@ class SeerConnect:  # pylint: disable=too-many-public-methods
         self.api_limit = 580
 
     def login(self, email=None, password=None):
-        self.seer_auth = SeerAuth(self.api_url, email, password)
+        self.seer_auth = SeerAuth(self.api_url, email, password, self.dev)
         cookie = self.seer_auth.cookie
-        header = {'Cookie': list(cookie.keys())[0] + '=' + cookie['seer.sid']}
+        header = {'Cookie': list(cookie.keys())[
+            0] + '=' + cookie['seerdev.sid'] if self.dev else cookie['seer.sid']}
 
         def graphql_client(party_id=None):
             url_suffix = '?partyId=' + party_id if party_id else ''

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -4,7 +4,7 @@ from unittest import mock
 
 import pytest
 
-from seerpy.auth import SeerAuth
+from seerpy.auth import SeerAuth, COOKIE_KEY_PROD
 
 
 # having a class is useful to allow patches to be shared across mutliple test functions, but then
@@ -25,18 +25,18 @@ class TestAuth:
     def test_success(self, read_cookie, requests_post,  # pylint:disable=unused-argument
                      requests_get, email_input, password_getpass):  # pylint:disable=unused-argument
         requests_post.return_value.status_code = 200
-        requests_post.return_value.cookies = {'seer.sid': "cookie"}
+        requests_post.return_value.cookies = {COOKIE_KEY_PROD: "cookie"}
         requests_get.return_value.status_code = 200
         requests_get.return_value.json.return_value = {"session": "active"}
 
         result = SeerAuth("api-url")
 
-        assert result.cookie['seer.sid'] == "cookie"
+        assert result.cookie[COOKIE_KEY_PROD] == "cookie"
 
     def test_401_error(self, requests_post, requests_get,
                        email_input, password_getpass):  # pylint:disable=unused-argument
         requests_post.return_value.status_code = 200
-        requests_post.return_value.cookies = {'seer.sid': "cookie"}
+        requests_post.return_value.cookies = {COOKIE_KEY_PROD: "cookie"}
         requests_get.return_value.status_code = 401
 
         with pytest.raises(InterruptedError):
@@ -45,7 +45,7 @@ class TestAuth:
     def test_other_error(self, requests_post, requests_get,
                          email_input, password_getpass):  # pylint:disable=unused-argument
         requests_post.return_value.status_code = 200
-        requests_post.return_value.cookies = {'seer.sid': "cookie"}
+        requests_post.return_value.cookies = {COOKIE_KEY_PROD: "cookie"}
         requests_get.return_value.status_code = "undefined"
 
         with pytest.raises(InterruptedError):

--- a/tests/test_seerpy.py
+++ b/tests/test_seerpy.py
@@ -9,6 +9,7 @@ import pandas as pd
 
 from seerpy.seerpy import SeerConnect
 import seerpy.graphql as graphql
+from seerpy.auth import COOKIE_KEY_PROD
 
 
 # having a class is useful to allow patches to be shared across mutliple test functions, but then
@@ -26,7 +27,7 @@ TEST_DATA_DIR = pathlib.Path(__file__).parent / "test_data"
 class TestSeerConnect:
 
     def test_success(self, seer_auth):
-        seer_auth.return_value.cookie = {'seer.sid': "cookie"}
+        seer_auth.return_value.cookie = {COOKIE_KEY_PROD: "cookie"}
 
         result = SeerConnect()
 
@@ -36,7 +37,7 @@ class TestSeerConnect:
         seer_auth.return_value.cookie = None
 
         # not really desired behaviour, just documenting current behaviour
-        with pytest.raises(AttributeError):
+        with pytest.raises(TypeError):
             SeerConnect()
 
     def test_login_error(self, seer_auth):
@@ -92,7 +93,7 @@ class TestGetAllStudyMetaDataByNames:
 
     def test_no_study_param(self, seer_auth, gql_client, unused_time_sleep):
         # setup
-        seer_auth.return_value.cookie = {'seer.sid': "cookie"}
+        seer_auth.return_value.cookie = {COOKIE_KEY_PROD: "cookie"}
 
         side_effects = []
 
@@ -121,7 +122,7 @@ class TestGetAllStudyMetaDataByNames:
 
     def test_existing_study_param(self, seer_auth, gql_client, unused_time_sleep):
         # setup
-        seer_auth.return_value.cookie = {'seer.sid': "cookie"}
+        seer_auth.return_value.cookie = {COOKIE_KEY_PROD: "cookie"}
 
         side_effects = []
 
@@ -148,7 +149,7 @@ class TestGetAllStudyMetaDataByNames:
 
     def test_getting_multiple_study_ids_by_name(self, seer_auth, gql_client, unused_time_sleep):
         # setup
-        seer_auth.return_value.cookie = {'seer.sid': "cookie"}
+        seer_auth.return_value.cookie = {COOKIE_KEY_PROD: "cookie"}
 
         side_effects = []
 
@@ -181,7 +182,7 @@ class TestGetAllStudyMetaDataByNames:
 
     def test_nonexistent_study_param(self, seer_auth, gql_client, unused_time_sleep):
         # setup
-        seer_auth.return_value.cookie = {'seer.sid': "cookie"}
+        seer_auth.return_value.cookie = {COOKIE_KEY_PROD: "cookie"}
 
         side_effects = []
 
@@ -206,7 +207,7 @@ class TestGetSegmentUrls:
 
     def test_success(self, seer_auth, gql_client, unused_time_sleep):
         # setup
-        seer_auth.return_value.cookie = {'seer.sid': "cookie"}
+        seer_auth.return_value.cookie = {COOKIE_KEY_PROD: "cookie"}
 
         with open(TEST_DATA_DIR / "segment_urls_1.json", "r") as f:
             gql_client.return_value.execute.return_value = json.load(f)
@@ -221,7 +222,7 @@ class TestGetSegmentUrls:
 
     def test_multiple_batches(self, seer_auth, gql_client, unused_time_sleep):
         # setup
-        seer_auth.return_value.cookie = {'seer.sid': "cookie"}
+        seer_auth.return_value.cookie = {COOKIE_KEY_PROD: "cookie"}
 
         side_effects = []
         for file_name in ["segment_urls_1.json", "segment_urls_2.json"]:
@@ -240,7 +241,7 @@ class TestGetSegmentUrls:
 
     def test_none_segment_ids(self, seer_auth, unused_gql_client, unused_time_sleep):
         # setup
-        seer_auth.return_value.cookie = {'seer.sid': "cookie"}
+        seer_auth.return_value.cookie = {COOKIE_KEY_PROD: "cookie"}
 
         expected_result = pd.read_csv(TEST_DATA_DIR / "segment_urls_empty.csv", index_col=0)
 
@@ -252,7 +253,7 @@ class TestGetSegmentUrls:
 
     def test_empty_segment_ids(self, seer_auth, unused_gql_client, unused_time_sleep):
         # setup
-        seer_auth.return_value.cookie = {'seer.sid': "cookie"}
+        seer_auth.return_value.cookie = {COOKIE_KEY_PROD: "cookie"}
 
         # gql_client is never called as we don't enter the loop
 
@@ -264,7 +265,7 @@ class TestGetSegmentUrls:
 
     def test_unmatched_segment_ids(self, seer_auth, gql_client, unused_time_sleep):
         # setup
-        seer_auth.return_value.cookie = {'seer.sid': "cookie"}
+        seer_auth.return_value.cookie = {COOKIE_KEY_PROD: "cookie"}
 
         with open(TEST_DATA_DIR / "segment_urls_no_match.json", "r") as f:
             gql_client.return_value.execute.return_value = json.load(f)
@@ -283,7 +284,7 @@ class TestGetLabels:
 
     def test_success(self, seer_auth, gql_client, unused_time_sleep):
         # setup
-        seer_auth.return_value.cookie = {'seer.sid': "cookie"}
+        seer_auth.return_value.cookie = {COOKIE_KEY_PROD: "cookie"}
 
         side_effects = []
 
@@ -314,7 +315,7 @@ class TestGetLabelsDataframe:
 
     def test_success(self, seer_auth, gql_client, unused_time_sleep):
         # setup
-        seer_auth.return_value.cookie = {'seer.sid': "cookie"}
+        seer_auth.return_value.cookie = {COOKIE_KEY_PROD: "cookie"}
 
         side_effects = []
 
@@ -344,7 +345,7 @@ class TestGetViewedTimesDataframe:
 
     def test_success(self, seer_auth, gql_client, unused_time_sleep):
         # setup
-        seer_auth.return_value.cookie = {'seer.sid': "cookie"}
+        seer_auth.return_value.cookie = {COOKIE_KEY_PROD: "cookie"}
 
         side_effects = []
 
@@ -375,7 +376,7 @@ class TestGetDocumentsForStudiesDataframe:
 
     def test_success(self, seer_auth, gql_client, unused_time_sleep):
         # setup
-        seer_auth.return_value.cookie = {'seer.sid': "cookie"}
+        seer_auth.return_value.cookie = {COOKIE_KEY_PROD: "cookie"}
 
         side_effects = []
 
@@ -405,7 +406,7 @@ class TestGetDocumentsForStudiesDataframe:
 @mock.patch('seerpy.seerpy.SeerAuth', autospec=True)
 class TestGetMoodSurveyResults:
     def test_get_results(self, seer_auth, gql_client):
-        seer_auth.return_value.cookie = {'seer.sid': "cookie"}
+        seer_auth.return_value.cookie = {COOKIE_KEY_PROD: "cookie"}
 
         side_effects = []
         with open(TEST_DATA_DIR / "mood_survey_response_1.json", "r") as f:
@@ -421,7 +422,7 @@ class TestGetMoodSurveyResults:
         assert result == expected_result
 
     def test_get_results_dataframe(self, seer_auth, gql_client):
-        seer_auth.return_value.cookie = {'seer.sid': "cookie"}
+        seer_auth.return_value.cookie = {COOKIE_KEY_PROD: "cookie"}
 
         side_effects = []
         with open(TEST_DATA_DIR / "mood_survey_response_1.json", "r") as f:
@@ -436,7 +437,7 @@ class TestGetMoodSurveyResults:
         pd.testing.assert_frame_equal(result, expected_result)
 
     def test_get_multiple_results_pages_dataframe(self, seer_auth, gql_client):
-        seer_auth.return_value.cookie = {'seer.sid': "cookie"}
+        seer_auth.return_value.cookie = {COOKIE_KEY_PROD: "cookie"}
 
         side_effects = []
         with open(TEST_DATA_DIR / "mood_survey_response_1.json", "r") as f:
@@ -453,7 +454,7 @@ class TestGetMoodSurveyResults:
         pd.testing.assert_frame_equal(result, expected_result)
 
     def test_get_empty_results_dataframe(self, seer_auth, gql_client):
-        seer_auth.return_value.cookie = {'seer.sid': "cookie"}
+        seer_auth.return_value.cookie = {COOKIE_KEY_PROD: "cookie"}
 
         side_effects = []
         with open(TEST_DATA_DIR / "mood_survey_response_empty.json", "r") as f:
@@ -469,7 +470,7 @@ class TestGetMoodSurveyResults:
 class TestStudyCohorts:
     def test_get_study_ids_in_study_cohort(self, seer_auth, gql_client):
         # setup
-        seer_auth.return_value.cookie = {'seer.sid': "cookie"}
+        seer_auth.return_value.cookie = {COOKIE_KEY_PROD: "cookie"}
 
         side_effects = []
 


### PR DESCRIPTION
This supports providing alternative API servers which follow a slightly different URL scheme, for instance testing or dev API servers which use `/api/development` instead of `/api`.