### PR TITLE
Avoid duplicating and / or skipping diary labels

### DIFF
--- a/seerpy/seerpy.py
+++ b/seerpy/seerpy.py
@@ -547,10 +547,14 @@ class SeerConnect:  # pylint: disable=too-many-public-methods
 
                 if label_results is None:
                     label_results = response
+                    if any([index['numberOfLabels'] for index in response['labelGroups'] if index['numberOfLabels'] >= limit]):
+                        query_flag = True
+                    break
+
                 else:
                     label_results['labelGroups'][idx]['labels'].extend(labels)
 
-                offset += limit
+            offset += limit
 
         return label_results
 


### PR DESCRIPTION
Fix two bugs in fetching diary labels
- BUG: label list was initialised twice if there was more than one label group, FIX: break out of the labelGroup loop after the first initialisation, and check if another query loop is needed (i.e. there are more labels to fetch).
- BUG: if there was more than one label group, labels were skipped for some groups, FIX: move the `offset = offset + limit` outside the labelGroup loop