### PR TITLE
Update FitBit data type

### DIFF
--- a/seerpy/graphql.py
+++ b/seerpy/graphql.py
@@ -519,9 +519,7 @@ def get_diary_study_channel_groups_query_string(patient_id, from_time, to_time):
                     channelGroups {
                         id
                         name
-                        recordsPerChunk
-                        sampleEncoding
-                        compression
+                        startTime
                         segments (ranges: [{ from: %.0f, to: %.0f }]) {
                             id
                             startTime

--- a/seerpy/seerpy.py
+++ b/seerpy/seerpy.py
@@ -9,6 +9,7 @@ from gql.transport.requests import RequestsHTTPTransport
 import pandas as pd
 from pandas.io.json import json_normalize
 import requests
+from datetime import datetime
 
 from .auth import SeerAuth, COOKIE_KEY_DEV, COOKIE_KEY_PROD
 from . import utils
@@ -840,8 +841,10 @@ class SeerConnect:  # pylint: disable=too-many-public-methods
 
         data_list = []
         for idx, url in enumerate(segment_urls):
+            start_time = datetime.utcfromtimestamp(start_times[idx]/1000)
             new_data = utils.get_diary_fitbit_data(url)
-            new_data['timestamp'] = new_data['timestamp'] + start_times[idx]
+            # convert timestamps to true utc datetime
+            new_data['timestamp'] = start_time + pd.to_timedelta(new_data['timestamp'], unit='ms')
             new_data['name'] = group_names[idx]
             data_list.append(new_data)
 


### PR DESCRIPTION
Fix for a bug where Fitbit data timestamps were duplicated because of rounding errors introduced by large floats (posix timestamps in milliseconds)

### Code changes:

- Convert Fitbit data timestamps to python DateTimes to work with timing and duration instead of float arithmetic. Returning dates as the datatype is likely to be less ambiguous for future researchers who use seer-py
- Update the data fields that get queried on a diary channel group by adding a `startTime` so that users know the absolute start of the Fitbit data, and removing some redundant information.