### PR TITLE
Better discoverability re. saving credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,23 @@ Check out the [Example](Examples/Example.ipynb) for a step-by-step example of ho
 
 To start a Jupyter notebook, run `jupyter notebook` in a command/bash window. Further instructions on Jupyter can be found here: https://github.com/jupyter/notebook
 
+## Authenticating
+
+To access data from the Seer platform you must first register for an account 
+at https://app.seermedical.com/. You can then use seer-py to authenticate with
+the API.
+
+Create an instance of the `SeerAuth` class (defined in _auth.py_) and provide
+your email address and password using one of the following options:
+
+1. Pass them as arguments when instantiating the `SeerAuth` object.
+2. In your home directory, create a  _.seerpy/_ folder, and within it a file
+  named _credentials_. Save your email address on the first line and your
+  password on the second line with no other text.
+3. If you don't use one of the previous options, you will be prompted for your
+  email address and password in the terminal or Jupyter notebook before you can
+  retrieve any data.
+
 ## Running with other API endpoints
 
 To run seer-py against other environments (for instance against a development API server), perform the following steps:

--- a/seerpy/auth.py
+++ b/seerpy/auth.py
@@ -13,6 +13,8 @@ COOKIE_KEY_DEV = 'seerdev.sid'
 
 class SeerAuth:
 
+    help_message_displayed = False
+
     def __init__(self, api_url, email=None, password=None, dev=False):
         self.api_url = api_url
         self.cookie = None
@@ -91,11 +93,15 @@ class SeerAuth:
         if os.path.isfile(pswdfile):
             with open(pswdfile, 'r') as f:
                 lines = f.readlines()
-                self.email = lines[0][:-1]
-                self.password = lines[1][:-1]
+                self.email = lines[0].rstrip()
+                self.password = lines[1].rstrip()
         else:
             self.email = input('Email Address: ')
             self.password = getpass.getpass('Password: ')
+            if not self.help_message_displayed:
+                print("\nHint: To skip this in future, save your details to ~/.seerpy/credentials")
+                print("See README.md - 'Authenticating' for details\n")
+                self.help_message_displayed = True
 
     def get_cookie_path(self):
         return '/.seerpy/cookie-dev' if self.dev else '/.seerpy/cookie'

--- a/seerpy/auth.py
+++ b/seerpy/auth.py
@@ -99,7 +99,7 @@ class SeerAuth:
             self.email = input('Email Address: ')
             self.password = getpass.getpass('Password: ')
             if not self.help_message_displayed:
-                print("\nHint: To skip this in future, save your details to ~/.seerpy/credentials")
+                print(f"\nHint: To skip this in future, save your details to {pswdfile}")
                 print("See README.md - 'Authenticating' for details\n")
                 self.help_message_displayed = True
 


### PR DESCRIPTION
There is currently no easy way for users to find out about saving their email/password to file to expedite the authentication process.

1. Add a section to the README explaining how authentication works and how you can save a credentials file
2. Print a hint message the first time email/password is manually entered
3. When reading the credentials file, right-strip lines instead of skipping the last character. This is robust to arbitrary whitespace, and means a newline isn't necessary following the password