### PR TITLE
Prompt to save user credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ To access data from the Seer platform you must first register for an account at
 https://app.seermedical.com/. You can then use seer-py to authenticate with the API.
 
 Create an instance of the `SeerAuth` class (defined in _auth.py_) and provide
-your email address and password using either of the following options:
+your email address and password using one of the following options:
 
 1. Pass them as arguments when instantiating a `SeerAuth` object.
 2. In your local user directory, create a _.seerpy/_ folder with a file named

--- a/README.md
+++ b/README.md
@@ -32,20 +32,19 @@ To start a Jupyter notebook, run `jupyter notebook` in a command/bash window. Fu
 
 ## Authenticating
 
-To access data from the Seer platform you must first register for an account 
-at https://app.seermedical.com/. You can then use seer-py to authenticate with
-the API.
+To access data from the Seer platform you must first register for an account at 
+https://app.seermedical.com/. You can then use seer-py to authenticate with the API.
 
 Create an instance of the `SeerAuth` class (defined in _auth.py_) and provide
-your email address and password using one of the following options:
+your email address and password using either of the following options:
 
-1. Pass them as arguments when instantiating the `SeerAuth` object.
-2. In your home directory, create a  _.seerpy/_ folder, and within it a file
-  named _credentials_. Save your email address on the first line and your
+1. Pass them as arguments when instantiating a `SeerAuth` object.
+2. In your local user directory, create a _.seerpy/_ folder with a file named
+  _credentials_ in it. Save your email address on the first line and your
   password on the second line with no other text.
-3. If you don't use one of the previous options, you will be prompted for your
-  email address and password in the terminal or Jupyter notebook before you can
-  retrieve any data.
+3. If you don't use one of the previous options, you will be prompted to enter
+  your email address and password in the terminal or Jupyter notebook before
+  you can retrieve any data.
 
 ## Running with other API endpoints
 

--- a/seerpy/auth.py
+++ b/seerpy/auth.py
@@ -93,8 +93,8 @@ class SeerAuth:
         if os.path.isfile(self.pswdfile):
             with open(self.pswdfile, 'r') as f:
                 lines = f.readlines()
-                self.email = lines[0].rstrip()
-                self.password = lines[1].rstrip()
+                self.email = lines[0].rstrip('\n')
+                self.password = lines[1].rstrip('\n')
         else:
             self.email = input('Email Address: ')
             self.password = getpass.getpass('Password: ')


### PR DESCRIPTION
(Full credit to @dkeden for this idea)

Instead of printing a message about where to save email & password to file, just ask user if they would like the file created for them.

## Notes
- After a successful login, check whether the password file exists. If not, ask user if they'd like it to be created
- This happens in the main `__init__()` loop so that the "Login Success" message gets printed first
- Only prompt once per SeerAuth client
- (I guess if someone really doesn't want the file created it could get annoying to say no each time - could save a little "do not prompt to save credentials" indicator file in _.seerpy_, and check for this before prompting - but maybe that's overkill)

## Other changes
- Factor out hard-coded paths to become class variables
- When reading password from file, retain any whitespace and just strip newlines
- Update README a little for clarity