### PR TITLE
Add function to request medication compliance from API

### DIFF
--- a/seerpy/graphql.py
+++ b/seerpy/graphql.py
@@ -373,6 +373,22 @@ def get_diary_labels_query_string(patient_id, limit, offset):
             }
         }""" % (patient_id, limit, offset)
 
+def get_diary_medication_compliance_query_string(patient_id, from_time, to_time):
+
+    return """
+        query {
+            patient (id: "%s") {
+                id
+                diary {
+                    id
+                    medicationCompliance (range: { from: %.0f, to: %.0f }) {
+                        label
+                        status
+                        date
+                    }
+                }
+            }
+        }""" % (patient_id, from_time, to_time)
 
 def get_documents_for_study_ids_paged_query_string(study_ids):
     study_ids_string = get_json_list(study_ids)

--- a/seerpy/seerpy.py
+++ b/seerpy/seerpy.py
@@ -583,6 +583,22 @@ class SeerConnect:  # pylint: disable=too-many-public-methods
         label_groups['id'] = patient_id
         return label_groups
 
+    def get_diary_medication_compliance(self, patient_id, from_time=0, to_time=0):
+
+        query_string = graphql.get_diary_medication_compliance_query_string(patient_id, from_time, to_time)
+        response = self.execute_query(query_string)
+
+        return response
+
+    def get_diary_medication_compliance_dataframe(self, patient_id, from_time=0, to_time=0):
+
+        results = self.get_diary_medication_compliance(patient_id, from_time, to_time)
+        if results is None:
+            return results
+
+        medication_compliance = json_normalize(results['patient']['diary']['medicationCompliance']).sort_index(axis=1)
+        medication_compliance['id'] = patient_id
+        return medication_compliance
 
     def get_all_study_metadata_by_names(self, study_names=None, party_id=None):
         """Get all the metadata available about named studies

--- a/seerpy/seerpy.py
+++ b/seerpy/seerpy.py
@@ -587,7 +587,6 @@ class SeerConnect:  # pylint: disable=too-many-public-methods
 
         query_string = graphql.get_diary_medication_compliance_query_string(patient_id, from_time, to_time)
         response = self.execute_query(query_string)
-
         return response
 
     def get_diary_medication_compliance_dataframe(self, patient_id, from_time=0, to_time=0):


### PR DESCRIPTION
- adds function to return medicationCompliance request
- adds function to return medicationCompliance request in DataFrame 

n.b. I've add a `patient_id` at the end of the _dataframe function, similar to `get_diary_labels_dataframe`, although adds to the last column. Can return a sorted or index this column if preferred?

Also, I'm not sure if there's a convention with naming variables so used `medication_compliance` to return the desired response / results, but happy to change 