### PR TITLE
Big documentation overhaul

### DIFF
--- a/.style.yapf
+++ b/.style.yapf
@@ -1,0 +1,7 @@
+[style]
+based_on_style = pep8
+column_limit = 100
+blank_line_before_nested_class_or_def = True
+dedent_closing_brackets = False
+split_before_named_assigns = False
+spaces_around_default_or_named_assign = False

--- a/.style.yapf
+++ b/.style.yapf
@@ -1,7 +1,13 @@
 [style]
-based_on_style = pep8
-column_limit = 100
-blank_line_before_nested_class_or_def = True
-dedent_closing_brackets = False
-split_before_named_assigns = False
-spaces_around_default_or_named_assign = False
+COLUMN_LIMIT = 100
+BASED_ON_STYLE = pep8
+SPLIT_BEFORE_NAMED_ASSIGNS = False
+SPLIT_BEFORE_ARITHMETIC_OPERATOR = True
+SPLIT_BEFORE_BITWISE_OPERATOR = True
+SPLIT_BEFORE_DICT_SET_GENERATOR = True
+SPLIT_BEFORE_LOGICAL_OPERATOR = True
+SPLIT_COMPLEX_COMPREHENSION = True
+DEDENT_CLOSING_BRACKETS = False
+SPACES_BEFORE_COMMENT = 2
+SPLIT_BEFORE_FIRST_ARGUMENT = False
+SPLIT_BEFORE_EXPRESSION_AFTER_OPENING_PAREN = True

--- a/pylintrc
+++ b/pylintrc
@@ -141,7 +141,8 @@ disable=print-statement,
         exception-escape,
         comprehension-escape,
         too-many-arguments,
-        missing-docstring  # temporary
+        too-many-locals,
+
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option

--- a/pylintrc
+++ b/pylintrc
@@ -140,6 +140,7 @@ disable=print-statement,
         deprecated-sys-function,
         exception-escape,
         comprehension-escape,
+        too-many-arguments,
         missing-docstring  # temporary
 
 # Enable the message, report, category or checker with the given id(s). You can

--- a/seerpy/__init__.py
+++ b/seerpy/__init__.py
@@ -1,1 +1,2 @@
+"""Seerpy package init file"""
 from .seerpy import SeerConnect

--- a/seerpy/auth.py
+++ b/seerpy/auth.py
@@ -1,21 +1,38 @@
-# Copyright 2017 Seer Medical Pty Ltd, Inc. or its affiliates. All Rights Reserved.
+"""
+Authenticate a connection by verifying a user's ID against the auth endpoint.
 
+Copyright 2017 Seer Medical Pty Ltd, Inc. or its affiliates. All Rights Reserved.
+"""
 import getpass
-import os
 import json
+import os
 
 import requests
 
-
+API_URL = 'https://api.seermedical.com/api'
 COOKIE_KEY_PROD = 'seer.sid'
 COOKIE_KEY_DEV = 'seerdev.sid'
 
 
 class SeerAuth:
+    """Class to handle authenticating a user"""
 
     help_message_displayed = False
+    seerpy_dir = f"{os.path.expanduser('~')}/.seerpy"
+    pswdfile = f"{seerpy_dir}/credentials"
 
-    def __init__(self, api_url, email=None, password=None, dev=False):
+    def __init__(self, api_url: str = API_URL, email: str = None, password: str = None,
+                 dev: bool = False):
+        """
+        Authenticate session using email address and password
+
+        Parameters
+        ----------
+        api_url: The base URL of the API endpoint
+        email: The email address for a user's https://app.seermedical.com account
+        password: The password for a user's https://app.seermedical.com account
+        dev: Flag to query the dev rather than production endpoint
+        """
         self.api_url = api_url
         self.cookie = None
         self.dev = dev
@@ -31,13 +48,13 @@ class SeerAuth:
 
         for i in range(allowed_attempts):
             if not self.email or not self.password:
-                self.login_details()
+                self.get_login_details()
             self.login()
             response = self.verify_login()
             if response == requests.codes.ok:  # pylint: disable=maybe-no-member
                 print('Login Successful')
                 break
-            elif i < allowed_attempts - 1:
+            if i < allowed_attempts - 1:
                 print('\nLogin error, please re-enter your email and password: \n')
                 self.cookie = None
                 self.password = None
@@ -48,14 +65,17 @@ class SeerAuth:
                 self.password = None
                 raise InterruptedError('Authentication Failed')
 
-    def login(self):
+    def login(self) -> None:
+        """
+        Request and save a session cookie from the auth endpoint, by making a
+        POST request with a user's email address and password.
+        """
         login_url = self.api_url + '/auth/login'
         body = {'email': self.email, 'password': self.password}
         response = requests.post(url=login_url, data=body)
-        print("login status_code", response.status_code)
-        if (response.status_code == requests.codes.ok  # pylint: disable=maybe-no-member
-                and response.cookies):
-
+        print("Login status code:", response.status_code)
+        # pylint: disable=maybe-no-member
+        if (response.status_code == requests.codes.ok and response.cookies):
             seer_sid = response.cookies.get(COOKIE_KEY_PROD, False)
             seerdev_sid = response.cookies.get(COOKIE_KEY_DEV, False)
 
@@ -64,69 +84,73 @@ class SeerAuth:
                 self.cookie[COOKIE_KEY_PROD] = seer_sid
             elif seerdev_sid:
                 self.cookie[COOKIE_KEY_DEV] = seerdev_sid
-
         else:
             self.cookie = None
 
-    def verify_login(self):
+    def verify_login(self) -> int:
+        """
+        Attempt to verify user by making a GET request with the current session cookie.
+        If successful, save cookie to disk. Returns response status code.
+        """
         if self.cookie is None:
             return 401
 
         verify_url = self.api_url + '/auth/verify'
         response = requests.get(url=verify_url, cookies=self.cookie)
         if response.status_code != requests.codes.ok:  # pylint: disable=maybe-no-member
-            print("api verify call returned",
-                  response.status_code, "status code")
+            print(f"API 'verify' call returned {response.status_code} status code")
             return 401
 
         json_response = response.json()
         if not json_response or not json_response['session'] == "active":
-            print("api verify call did not return an active session")
+            print("API 'verify' call did not return an active session")
             return 401
 
         self.write_cookie()
         return response.status_code
 
-    def login_details(self):
-        home = os.path.expanduser('~')
-        pswdfile = home + '/.seerpy/credentials'
-        if os.path.isfile(pswdfile):
-            with open(pswdfile, 'r') as f:
+    def get_login_details(self) -> None:
+        """
+        Read in user's email address and password, either from file or stdin.
+        """
+        if os.path.isfile(self.pswdfile):
+            with open(self.pswdfile, 'r') as f:
                 lines = f.readlines()
-                self.email = lines[0].rstrip()
-                self.password = lines[1].rstrip()
+                self.email = lines[0].rstrip('\n')
+                self.password = lines[1].rstrip('\n')
         else:
             self.email = input('Email Address: ')
             self.password = getpass.getpass('Password: ')
             if not self.help_message_displayed:
-                print(f"\nHint: To skip this in future, save your details to {pswdfile}")
+                print(f"\nHint: To skip this in future, save your details to {self.pswdfile}")
                 print("See README.md - 'Authenticating' for details\n")
                 self.help_message_displayed = True
 
-    def get_cookie_path(self):
-        return '/.seerpy/cookie-dev' if self.dev else '/.seerpy/cookie'
+    def get_cookie_path(self) -> str:
+        """Get the path to the local cookie file"""
+        return f"{self.seerpy_dir}/cookie-dev" if self.dev else f"{self.seerpy_dir}/cookie"
 
-    def write_cookie(self):
+    def write_cookie(self) -> None:
+        """Save the current cookie to file"""
         try:
-            home = os.path.expanduser('~')
-            cookie_file = home + self.get_cookie_path()
-            if not os.path.isdir(home + '/.seerpy'):
-                os.mkdir(home + '/.seerpy')
+            cookie_file = self.get_cookie_path()
+            if not os.path.isdir(self.seerpy_dir):
+                os.mkdir(self.seerpy_dir)
             with open(cookie_file, 'w') as f:
                 f.write(json.dumps(self.cookie))
         except Exception:  # pylint:disable=broad-except
             pass
 
-    def read_cookie(self):
-        home = os.path.expanduser('~')
-        cookie_file = home + self.get_cookie_path()
+    def read_cookie(self) -> None:
+        """Read the latest cookie saved to file"""
+        cookie_file = self.get_cookie_path()
         if os.path.isfile(cookie_file):
             with open(cookie_file, 'r') as f:
                 self.cookie = json.loads(f.read().strip())
 
-    def destroy_cookie(self):
-        home = os.path.expanduser('~')
-        cookie_file = home + self.get_cookie_path()
+    def destroy_cookie(self) -> None:
+        """Delete any saved cookie"""
+        cookie_file = self.get_cookie_path()
         if os.path.isfile(cookie_file):
             os.remove(cookie_file)
         self.cookie = None

--- a/seerpy/auth.py
+++ b/seerpy/auth.py
@@ -9,7 +9,6 @@ import os
 
 import requests
 
-API_URL = 'https://api.seermedical.com/api'
 COOKIE_KEY_PROD = 'seer.sid'
 COOKIE_KEY_DEV = 'seerdev.sid'
 
@@ -21,8 +20,7 @@ class SeerAuth:
     seerpy_dir = f"{os.path.expanduser('~')}/.seerpy"
     pswdfile = f"{seerpy_dir}/credentials"
 
-    def __init__(self, api_url: str = API_URL, email: str = None, password: str = None,
-                 dev: bool = False):
+    def __init__(self, api_url: str, email: str = None, password: str = None, dev: bool = False):
         """
         Authenticate session using email address and password
 

--- a/seerpy/auth.py
+++ b/seerpy/auth.py
@@ -98,12 +98,12 @@ class SeerAuth:
         verify_url = self.api_url + '/auth/verify'
         response = requests.get(url=verify_url, cookies=self.cookie)
         if response.status_code != requests.codes.ok:  # pylint: disable=maybe-no-member
-            print(f"API 'verify' call returned {response.status_code} status code")
+            print(f"API verify call returned {response.status_code} status code")
             return 401
 
         json_response = response.json()
         if not json_response or not json_response['session'] == "active":
-            print("API 'verify' call did not return an active session")
+            print("API verify call did not return an active session")
             return 401
 
         self.write_cookie()

--- a/seerpy/graphql.py
+++ b/seerpy/graphql.py
@@ -1,15 +1,34 @@
-# pylint:disable=too-many-arguments
+"""
+GraphQL queries exposed by various seerpy.SeerConnect wrapper functions.
+"""
+# pylint:disable=too-many-arguments,missing-function-docstring
+from typing import Any, Dict, List
+
 from . import utils
 
 
-def get_json_list(list_of_strings, include_brackets=True):
+def get_json_list(list_of_strings: List[str], include_brackets: bool = True) -> str:
+    """
+    Convert a list of strings into a single comma-separated string, as per
+    string-ified JSON format.
+
+    Paramters
+    ---------
+    list_of_strings: Strings to convert to single string
+    include_backets: Whether to include square braces in the returned string
+    """
     json_list = ', '.join('"%s"' % string for string in list_of_strings)
     if include_brackets:
         json_list = '[' + json_list + ']'
     return json_list
 
 
-def get_string_from_list_of_dicts(list_of_dicts):
+def get_string_from_list_of_dicts(list_of_dicts: List[Dict[str, Any]]):
+    """
+    Convert a list of dicts into a flattened string representation, e.g.
+    >>> get_string_from_list_of_dicts([{'a': 'this', 'b': 'that'}, {'c': 'next'}])
+    >>> ' { a: "this", b: "that"}, { c: "next"}'
+    """
     labels_string = ''
     for d in list_of_dicts:
         labels_string += ' {'

--- a/seerpy/graphql.py
+++ b/seerpy/graphql.py
@@ -1,3 +1,4 @@
+# pylint:disable=too-many-arguments
 from . import utils
 
 
@@ -77,8 +78,7 @@ def get_study_with_data_query_string(study_id):
         }""" % study_id
 
 
-def get_labels_query_string(study_id, label_group_id,  # pylint:disable=too-many-arguments
-                            from_time, to_time, limit, offset):
+def get_labels_query_string(study_id, label_group_id, from_time, to_time, limit, offset):
     return """
         query {
             study (id: "%s") {
@@ -120,8 +120,7 @@ def get_labels_query_string(study_id, label_group_id,  # pylint:disable=too-many
         }""" % (study_id, label_group_id, limit, offset, from_time, to_time)
 
 
-def get_labels_string_query_string(study_id, label_group_id,  # pylint:disable=too-many-arguments
-                                   from_time, to_time):
+def get_labels_string_query_string(study_id, label_group_id, from_time, to_time):
     return """
         query {
             study (id: "%s") {
@@ -373,6 +372,7 @@ def get_diary_labels_query_string(patient_id, limit, offset):
             }
         }""" % (patient_id, limit, offset)
 
+
 def get_diary_medication_compliance_query_string(patient_id, from_time, to_time):
 
     return """
@@ -389,6 +389,7 @@ def get_diary_medication_compliance_query_string(patient_id, from_time, to_time)
                 }
             }
         }""" % (patient_id, from_time, to_time)
+
 
 def get_documents_for_study_ids_paged_query_string(study_ids):
     study_ids_string = get_json_list(study_ids)
@@ -499,8 +500,8 @@ def get_diary_study_label_groups_string(patient_id, limit, offset):
     """ % (patient_id, limit, offset)
 
 
-def get_labels_for_diary_study_query_string(patient_id, label_group_id,  # pylint:disable=too-many-arguments
-                                            from_time, to_time, limit, offset):
+def get_labels_for_diary_study_query_string(patient_id, label_group_id, from_time, to_time, limit,
+                                            offset):
     return """
         query {
             patient (id: "%s") {
@@ -575,8 +576,7 @@ def create_study_cohort_mutation_string(name, description=None, key=None, study_
         args.append(('key', utils.quote_str(key)))
 
     if study_ids is not None:
-        args.append(
-            ('studyIds', get_json_list(study_ids)))
+        args.append(('studyIds', get_json_list(study_ids)))
 
     return """
         mutation {
@@ -603,10 +603,7 @@ def add_studies_to_study_cohort_mutation_string(study_cohort_id, study_ids):
                 }
             }
         }
-    """ % (
-        utils.quote_str(study_cohort_id),
-        get_json_list(study_ids)
-    )
+    """ % (utils.quote_str(study_cohort_id), get_json_list(study_ids))
 
 
 def remove_studies_from_study_cohort_mutation_string(study_cohort_id, study_ids):
@@ -621,10 +618,7 @@ def remove_studies_from_study_cohort_mutation_string(study_cohort_id, study_ids)
                 }
             }
         }
-    """ % (
-        utils.quote_str(study_cohort_id),
-        get_json_list(study_ids)
-    )
+    """ % (utils.quote_str(study_cohort_id), get_json_list(study_ids))
 
 
 def get_mood_survey_results_query_string(survey_template_ids, limit, offset):
@@ -642,11 +636,9 @@ def get_mood_survey_results_query_string(survey_template_ids, limit, offset):
             lastSubmittedAt
         }
     }
-    """ % (
-        ','.join([f'"{survey_template_id}"' for survey_template_id in survey_template_ids]),
-        limit,
-        offset
-    )
+    """ % (','.join([f'"{survey_template_id}"'
+                     for survey_template_id in survey_template_ids]), limit, offset)
+
 
 def get_user_ids_in_user_cohort_query_string(user_cohort_id, limit, offset):
     return """
@@ -672,8 +664,7 @@ def get_create_user_cohort_mutation_string(name, description=None, key=None, use
         args.append(('key', utils.quote_str(key)))
 
     if user_ids is not None:
-        args.append(
-            ('userIds', get_json_list(user_ids)))
+        args.append(('userIds', get_json_list(user_ids)))
 
     return """
         mutation {
@@ -700,10 +691,7 @@ def get_add_users_to_user_cohort_mutation_string(user_cohort_id, user_ids):
                 }
             }
         }
-    """ % (
-        utils.quote_str(user_cohort_id),
-        get_json_list(user_ids)
-    )
+    """ % (utils.quote_str(user_cohort_id), get_json_list(user_ids))
 
 
 def get_remove_users_from_user_cohort_mutation_string(user_cohort_id, user_ids):
@@ -718,7 +706,4 @@ def get_remove_users_from_user_cohort_mutation_string(user_cohort_id, user_ids):
                 }
             }
         }
-    """ % (
-        utils.quote_str(user_cohort_id),
-        get_json_list(user_ids)
-    )
+    """ % (utils.quote_str(user_cohort_id), get_json_list(user_ids))

--- a/seerpy/graphql.py
+++ b/seerpy/graphql.py
@@ -303,7 +303,8 @@ def get_remove_label_group_mutation_string(group_id):
     return """
         mutation {
             removeLabelGroupFromStudy(groupId: "%s")
-        }""" % (group_id)
+        }""" % (
+        group_id)
 
 
 def get_viewed_times_query_string(study_id, limit, offset):

--- a/seerpy/seerpy.py
+++ b/seerpy/seerpy.py
@@ -38,7 +38,7 @@ import pandas as pd
 from pandas.io.json import json_normalize
 import requests
 
-from .auth import SeerAuth, API_URL, COOKIE_KEY_DEV, COOKIE_KEY_PROD
+from .auth import SeerAuth, COOKIE_KEY_DEV, COOKIE_KEY_PROD
 from . import utils
 from . import graphql
 
@@ -52,8 +52,8 @@ class SeerConnect:
 
     # pylint: disable=too-many-public-methods
 
-    def __init__(self, api_url: str = API_URL, email: str = None, password: str = None,
-                 dev: bool = False):
+    def __init__(self, api_url: str = 'https://api.seermedical.com/api', email: str = None,
+                 password: str = None, dev: bool = False):
         """
         Create a GraphQL client able to interact with the Seer API endpoint,
         handling login and authorisation.

--- a/seerpy/seerpy.py
+++ b/seerpy/seerpy.py
@@ -472,8 +472,8 @@ class SeerConnect:
 
         study_metadata = study_metadata.drop_duplicates('segments.id')
         study_metadata = study_metadata[study_metadata['segments.startTime'] <= to_time]
-        study_metadata = study_metadata[study_metadata['segments.startTime'] +
-                                        study_metadata['segments.duration'] >= from_time]
+        study_metadata = study_metadata[study_metadata['segments.startTime']
+                                        + study_metadata['segments.duration'] >= from_time]
 
         data_chunks = []
         chunk_metadata = []
@@ -614,8 +614,8 @@ class SeerConnect:
         if label_results is None:
             return label_results
         label_group = json_normalize(label_results).sort_index(axis=1)
-        label_group['labelGroup.labelString'] = (label_group['labelGroup.labelString'].apply(
-            json.loads))
+        label_group['labelGroup.labelString'] = (
+            label_group['labelGroup.labelString'].apply(json.loads))
         labels = self.pandas_flatten(label_group, 'labelGroup.', 'labelString')
         label_group = label_group.drop('labelGroup.labelString', errors='ignore', axis='columns')
         label_group = label_group.merge(labels, how='left', on='labelGroup.id', suffixes=('', '_y'))
@@ -818,7 +818,8 @@ class SeerConnect:
                 if label_results is None:
                     label_results = response
                     if any([
-                            index['numberOfLabels'] for index in response['labelGroups']
+                            index['numberOfLabels']
+                            for index in response['labelGroups']
                             if index['numberOfLabels'] >= limit
                     ]):
                         query_flag = True
@@ -972,8 +973,8 @@ class SeerConnect:
 
         return {'studies': result}
 
-    def get_all_study_metadata_dataframe_by_names(
-            self, study_names: Iterable[str] = None) -> pd.DataFrame:
+    def get_all_study_metadata_dataframe_by_names(self, study_names: Iterable[str] = None
+                                                  ) -> pd.DataFrame:
         """
         Get all metadata available about studies with the suppled names as a
         DataFrame. See `get_all_study_metadata_by_ids()` for details.

--- a/seerpy/seerpy.py
+++ b/seerpy/seerpy.py
@@ -204,7 +204,7 @@ class SeerConnect:
             child = pd.DataFrame(columns=columns)
         return child
 
-    def add_label_group(self, study_id: str, name: str, description: str, label_type=None,
+    def add_label_group(self, study_id: str, name: str, description: str, label_type: str = None,
                         party_id: str = None) -> str:
         """
         Add a new label group to a study, returning the ID of the newly created
@@ -1058,7 +1058,8 @@ class SeerConnect:
         offset: The index of the first label group to return. Useful in
             conjunction with `limit` for repeated calls
         """
-        # TODO use limit/offset for pagination (unlikely to be more than 20 label groups for a while)
+        # TODO use limit/offset for pagination -
+        # Unlikely to be more than 20 label groups for a while)
         query_string = graphql.get_diary_study_label_groups_string(patient_id, limit, offset)
         response = self.execute_query(query_string)['patient']['diaryStudy']
         label_groups = response['labelGroups']

--- a/seerpy/utils.py
+++ b/seerpy/utils.py
@@ -8,7 +8,7 @@ import functools
 import gzip
 from multiprocessing import Pool
 import os
-from typing import Callable, List, Union
+from typing import Any, Callable, List, Union
 
 from matplotlib.collections import LineCollection
 from matplotlib import gridspec
@@ -19,7 +19,7 @@ import requests
 from scipy.signal import butter, sosfilt
 
 
-def download_channel_data(data_q: List[pd.Series, str, str, str, List[str]],
+def download_channel_data(data_q: List[Any],
                           download_function: Callable) -> pd.DataFrame:
     """
     Download data for a single channel of a single segment, decompress if

--- a/seerpy/utils.py
+++ b/seerpy/utils.py
@@ -19,8 +19,7 @@ import requests
 from scipy.signal import butter, sosfilt
 
 
-def download_channel_data(data_q: List[Any],
-                          download_function: Callable) -> pd.DataFrame:
+def download_channel_data(data_q: List[Any], download_function: Callable) -> pd.DataFrame:
     """
     Download data for a single channel of a single segment, decompress if
     needed, convert to numeric type, apply exponentiation etc, and return as a
@@ -84,9 +83,9 @@ def download_channel_data(data_q: List[Any],
         data = data.fillna(method='ffill', axis='columns')
         data = data.fillna(method='bfill', axis='columns')
         data = data.fillna(value=0., axis='columns')
-        data['time'] = (np.arange(data.shape[0]) *
-                        (1000.0 / meta_data['channelGroups.sampleRate']) +
-                        meta_data['dataChunks.time'])
+        data['time'] = (
+            np.arange(data.shape[0]) *
+            (1000.0 / meta_data['channelGroups.sampleRate']) + meta_data['dataChunks.time'])
         data['id'] = study_id
         data['channelGroups.id'] = channel_groups_id
         data['segments.id'] = segments_id
@@ -128,8 +127,8 @@ def create_data_chunk_urls(metadata: pd.DataFrame, segment_urls: pd.DataFrame, f
     for index in range(len(metadata.index)):
         row = metadata.iloc[index]
 
-        seg_base_urls = segment_urls.loc[segment_urls['segments.id'] == row['segments.id'],
-                                         'baseDataChunkUrl']
+        seg_base_urls = segment_urls.loc[segment_urls['segments.id'] ==
+                                         row['segments.id'], 'baseDataChunkUrl']
         if seg_base_urls.empty:
             continue
         seg_base_url = seg_base_urls.iloc[0]
@@ -251,8 +250,8 @@ def get_channel_names_or_ids(metadata: pd.DataFrame) -> List[str]:
 
 
 def plot_eeg(x: Union[np.ndarray, pd.Series], y: np.ndarray = None,
-             pred: Union[List[float], pd.Series,
-                         np.ndarray] = None, squeeze: float = 5.0, scaling_factor=None) -> plt:
+             pred: Union[List[float], pd.Series, np.ndarray] = None, squeeze: float = 5.0,
+             scaling_factor=None) -> plt:
     """
     Plot EEG data as a time series.
 

--- a/seerpy/utils.py
+++ b/seerpy/utils.py
@@ -34,7 +34,7 @@ def download_channel_data(data_q: List[pd.Series, str, str, str, List[str]],
     download_function: A callable that will be used to attempt to download data
         available at the URL defined in data_q[0]['dataChunks.url']
     """
-    # pylint: disabe=too-many-statements
+    # pylint: disable=too-many-statements
     meta_data, study_id, channel_groups_id, segments_id, channel_names = data_q
     try:
         raw_data = download_function(meta_data['dataChunks.url'])


### PR DESCRIPTION
Sling a dizzying number docstrings and type hints all over Seerpy.

- YAPF everything (inc. adding a YAPF style file)
- Pylint and address all manageable issues, i.e. everything except TODOs and "Too many lines in module" for _seerpy.py_
- Delete `"Notes"` `"Returns"` sections from docstrings as these were almost always either:
    - empty
    - obvious/unhelpful
    - not needed now there are type hints, return types and detailed docstrings

### Minor functionality changes
1. Add `seerpy_dir` and `pswdfile` class attributes to `SeerAuth` so that these aren't re-hardcoded across functions
1. Handle passwords that end in whitespace in `SeerAuth` (potential minor bugfix)
1. Add instance attrs that get attached to `SeerConnect` in `login()` as `None` types in the constructor - improves performance in Python as well as discoverability
1. Remove some unnecessary `elif`/`else` statements (that don't actually change functionality)
1. Add a `sort=True` to suppress a Pandas FutureWarning (no functionality change)