### PR TITLE
Add function to get createdAt field for diary labels  

### DIFF
--- a/seerpy/graphql.py
+++ b/seerpy/graphql.py
@@ -345,7 +345,7 @@ def get_diary_created_at_query_string(patient_id):
             }
         }""" % patient_id
 
-def get_diary_labels_query_string(patient_id, limit, offset):
+def get_diary_labels_query_string(patient_id, label_type, limit, offset, from_time, to_time, from_duration, to_duration):
     return """
         query {
             patient (id: "%s") {
@@ -359,7 +359,7 @@ def get_diary_labels_query_string(patient_id, limit, offset):
                         labelSourceType
                         name
                         numberOfLabels
-                        labels(limit: %.0f, offset: %.0f) {
+                        labels(limit: %.0f, offset: %.0f, ranges: [{ from: %.0f to: %.0f }, { from: %.0f to: %.0f }]) {
                             id
                             startTime
                             timezone
@@ -381,7 +381,7 @@ def get_diary_labels_query_string(patient_id, limit, offset):
                     }
                 }
             }
-        }""" % (patient_id, limit, offset)
+        }""" % (patient_id, label_type, limit, offset, from_time, to_time, from_duration, to_duration)
 
 def get_diary_medication_alerts_query_string(patient_id, from_time, to_time):
 

--- a/seerpy/graphql.py
+++ b/seerpy/graphql.py
@@ -353,7 +353,7 @@ def get_diary_labels_query_string(patient_id, label_type, limit, offset, from_ti
                 diary {
                     id
                     createdAt
-                    labelGroups {
+                    labelGroups (filters: [{name: "labelType", value:"%s"}]) {
                         id
                         labelType
                         labelSourceType

--- a/seerpy/graphql.py
+++ b/seerpy/graphql.py
@@ -335,6 +335,15 @@ def get_patients_query_string():
             }
         }"""
 
+def get_diary_created_at_query_string(patient_id):
+    return """
+        query {
+            patient (id: "%s") {
+                diary {
+                    createdAt
+                }
+            }
+        }""" % patient_id
 
 def get_diary_labels_query_string(patient_id, limit, offset):
     return """
@@ -343,6 +352,7 @@ def get_diary_labels_query_string(patient_id, limit, offset):
                 id
                 diary {
                     id
+                    createdAt
                     labelGroups {
                         id
                         labelType

--- a/seerpy/seerpy.py
+++ b/seerpy/seerpy.py
@@ -528,6 +528,11 @@ class SeerConnect:  # pylint: disable=too-many-public-methods
                 documents.append(document)
         return pd.DataFrame(documents)
 
+    def get_diary_created_at(self, patient_id):
+        query_string = graphql.get_diary_created_at_query_string(patient_id)
+        response = self.execute_query(query_string)['patient']['diary']['createdAt']
+        return response
+
     def get_diary_labels(self, patient_id, offset=0, limit=100):
         label_results = None
         # set true if we need to fetch labels
@@ -581,6 +586,7 @@ class SeerConnect:  # pylint: disable=too-many-public-methods
         label_groups = label_groups.merge(tags, how='left', on='labels.id', suffixes=('', '_y'))
         label_groups = label_groups.rename({'id':'labelGroups.id'})
         label_groups['id'] = patient_id
+        label_groups['createdAt'] = label_results['createdAt']
         return label_groups
 
     def get_diary_medication_alerts(self, patient_id, from_time=0, to_time=9e12):


### PR DESCRIPTION
This PR adds a function to request the `createdAt` field (from the API) for a given `patient_id`. The `createdAt` field indicates when a diary was created (i.e. when the user signed up).

I have also added the `createdAt` field in the `get_diary_labels` query string, and added a line for the dataframe. It may be redundant to add in both places, but figured that in cases when just the `createdAt` is required, it would be unnecessary to request all diary labels.

New:
seerpy: `get_diary_created_at()`
graphql: `get_diary_created_at_query_string()`

Changes:
seerpy: `get_diary_labels_dataframe()` --> added line
graphql: `get_diary_labels_query_string()` --> added line

