### PR TITLE
Add optional args / filters for diary labels

### DIFF
--- a/seerpy/graphql.py
+++ b/seerpy/graphql.py
@@ -336,20 +336,20 @@ def get_patients_query_string():
         }"""
 
 
-def get_diary_labels_query_string(patient_id, limit, offset):
+def get_diary_labels_query_string(patient_id, label_type, limit, offset, from_time, to_time, from_duration, to_duration):
     return """
         query {
             patient (id: "%s") {
                 id
                 diary {
                     id
-                    labelGroups {
+                    labelGroups (filters: [{name: "labelType", value:"%s"}]) {
                         id
                         labelType
                         labelSourceType
                         name
                         numberOfLabels
-                        labels(limit: %.0f, offset: %.0f) {
+                        labels(limit: %.0f, offset: %.0f, ranges: [{ from: %.0f to: %.0f }, { from: %.0f to: %.0f }]) {
                             id
                             startTime
                             timezone
@@ -371,7 +371,7 @@ def get_diary_labels_query_string(patient_id, limit, offset):
                     }
                 }
             }
-        }""" % (patient_id, limit, offset)
+        }""" % (patient_id, label_type, limit, offset, from_time, to_time, from_duration, to_duration)
 
 def get_diary_medication_alerts_query_string(patient_id, from_time, to_time):
 

--- a/seerpy/seerpy.py
+++ b/seerpy/seerpy.py
@@ -565,9 +565,9 @@ class SeerConnect:  # pylint: disable=too-many-public-methods
 
         return label_results
 
-    def get_diary_labels_dataframe(self, patient_id):
+    def get_diary_labels_dataframe(self, patient_id, label_type='all', offset=0, limit=100, from_time=0, to_time=9e12, from_duration=0, to_duration=9e12):
 
-        label_results = self.get_diary_labels(patient_id)
+        label_results = self.get_diary_labels(patient_id, label_type, offset, limit, from_time, to_time, from_duration, to_duration)
         if label_results is None:
             return label_results
 

--- a/seerpy/seerpy.py
+++ b/seerpy/seerpy.py
@@ -528,7 +528,7 @@ class SeerConnect:  # pylint: disable=too-many-public-methods
                 documents.append(document)
         return pd.DataFrame(documents)
 
-    def get_diary_labels(self, patient_id, offset=0, limit=100):
+    def get_diary_labels(self, patient_id, label_type='all', offset=0, limit=100, from_time=0, to_time=9e12, from_duration=0, to_duration=9e12):
         label_results = None
         # set true if we need to fetch labels
         query_flag = True
@@ -537,7 +537,7 @@ class SeerConnect:  # pylint: disable=too-many-public-methods
             if not query_flag:
                 break
 
-            query_string = graphql.get_diary_labels_query_string(patient_id, limit, offset)
+            query_string = graphql.get_diary_labels_query_string(patient_id, label_type, limit, offset, from_time, to_time, from_duration, to_duration)
             response = self.execute_query(query_string)['patient']['diary']
             label_groups = response['labelGroups']
 

--- a/seerpy/seerpy.py
+++ b/seerpy/seerpy.py
@@ -529,6 +529,40 @@ class SeerConnect:  # pylint: disable=too-many-public-methods
         return pd.DataFrame(documents)
 
     def get_diary_labels(self, patient_id, label_type='all', offset=0, limit=100, from_time=0, to_time=9e12, from_duration=0, to_duration=9e12):
+        """
+        Retrieves diary label groups and labels for a given patient.
+
+        Parameters
+        ----------
+        patient_id: str
+                Seer patient ID
+        label_type: str
+                The type of label to retrieve. Default = 'all'. Options = 'seizure',
+                'medications', 'cardiac'.
+        offset: int
+                Index of first record to return
+        limit: int
+                Batch size for repeated API calls
+        from_time: int
+                UTC timestamp to apply a range filter on label start times.
+                Retrieves labels after the given from_time
+        to_time: int
+                UTC timestamp to apply a range filter label start times.
+                Retrieves labels before the given to_time
+        from_duration: int
+                Time in millseconds to apply a range filter on the duration of labels.
+                Retrieves labels of duration > from_duration
+        to_duration: int
+                Time in milliseconds to apply a range filter on the duration of labels.
+                Retrieves labels of duration < to_duration
+
+        Returns
+        -------
+        label_results: dict
+                Returns a dict with keys 'id' and 'labelGroups'; 'labelGroups' indexes
+                to a list of dict with keys ['id', 'labelType', 'name', 'labels',
+                'numberOfLabels', 'labelSourceType']
+        """
         label_results = None
         # set true if we need to fetch labels
         query_flag = True


### PR DESCRIPTION
This PR adds optional arguments for filtering diary labels. The following arguments have been added to `get_diary_labels`:

- `label_type=all`: Default is all. Other options are `seizure`, `medications`, `cardiac` etc., as in API.
- `from_time` & `to_time`: Defaults are 0 and 9e12. This reflects recent changes in API where the first range in `ranges` is used to filter the `startTime` of diary labels.
- `from_duration` & `to_duration`: Defaults are 0 and 9e12. This reflects recent changes in API where the second range in `ranges` is used to filter the `duration` of diary labels.

This PR also adds all existing and new arguments to the `get_diary_labels_dataframe` function.