### PR TITLE
Add docstrings

### DIFF
--- a/seerpy/auth.py
+++ b/seerpy/auth.py
@@ -1,5 +1,5 @@
 """
-Authenticate a connection by verifying a user's ID against the auth endpoint.
+Authenticate a connection by verifying a user's credentials against the auth endpoint.
 
 Copyright 2017 Seer Medical Pty Ltd, Inc. or its affiliates. All Rights Reserved.
 """

--- a/seerpy/auth.py
+++ b/seerpy/auth.py
@@ -1,5 +1,8 @@
-# Copyright 2017 Seer Medical Pty Ltd, Inc. or its affiliates. All Rights Reserved.
+"""
+Authenticate a connection by verifying a user's ID against the auth endpoint.
 
+Copyright 2017 Seer Medical Pty Ltd, Inc. or its affiliates. All Rights Reserved.
+"""
 import getpass
 import os
 import json
@@ -12,10 +15,25 @@ COOKIE_KEY_DEV = 'seerdev.sid'
 
 
 class SeerAuth:
+    """Class to handle authenticating a user"""
 
     help_message_displayed = False
 
     def __init__(self, api_url, email=None, password=None, dev=False):
+        """
+        Authenticate session using email address and password
+
+        Parameters
+        ----------
+        api_url : str
+            Base URL of API endpoint
+        email : str
+            The email address for a user's Seer account
+        password : str
+            The password for a user's Seer account
+        dev : bool
+            Flag to query the dev rather than production endpoint
+        """
         self.api_url = api_url
         self.cookie = None
         self.dev = dev
@@ -49,6 +67,10 @@ class SeerAuth:
                 raise InterruptedError('Authentication Failed')
 
     def login(self):
+        """
+        Request and save a session cookie from the auth endpoint, by making a
+        POST request with a user's email address and password.
+        """
         login_url = self.api_url + '/auth/login'
         body = {'email': self.email, 'password': self.password}
         response = requests.post(url=login_url, data=body)
@@ -69,6 +91,10 @@ class SeerAuth:
             self.cookie = None
 
     def verify_login(self):
+        """
+        Attempt to verify user by making a GET request with the current session cookie.
+        If successful, save cookie to disk. Returns response status code.
+        """
         if self.cookie is None:
             return 401
 
@@ -88,6 +114,9 @@ class SeerAuth:
         return response.status_code
 
     def login_details(self):
+        """
+        Get user's email address and password, either from file or stdin.
+        """
         home = os.path.expanduser('~')
         pswdfile = home + '/.seerpy/credentials'
         if os.path.isfile(pswdfile):
@@ -104,9 +133,11 @@ class SeerAuth:
                 self.help_message_displayed = True
 
     def get_cookie_path(self):
+        """Get the path to the local cookie file"""
         return '/.seerpy/cookie-dev' if self.dev else '/.seerpy/cookie'
 
     def write_cookie(self):
+        """Save the current cookie to file"""
         try:
             home = os.path.expanduser('~')
             cookie_file = home + self.get_cookie_path()
@@ -118,6 +149,7 @@ class SeerAuth:
             pass
 
     def read_cookie(self):
+        """Read the latest cookie saved to file"""
         home = os.path.expanduser('~')
         cookie_file = home + self.get_cookie_path()
         if os.path.isfile(cookie_file):
@@ -125,6 +157,7 @@ class SeerAuth:
                 self.cookie = json.loads(f.read().strip())
 
     def destroy_cookie(self):
+        """Delete any saved cookie"""
         home = os.path.expanduser('~')
         cookie_file = home + self.get_cookie_path()
         if os.path.isfile(cookie_file):

--- a/seerpy/graphql.py
+++ b/seerpy/graphql.py
@@ -1,7 +1,34 @@
+"""
+GraphQL queries used by various seerpy.SeerConnect methods.
+"""
 from . import utils
 
 
 def get_json_list(list_of_strings, include_brackets=True):
+    """
+    Convert a list of strings into a single string representation, suitable for
+    inclusion in GraphQL queries.
+
+    Parameters
+    ---------
+    list_of_strings : list of str
+        Strings to convert to single string
+    include_backets : bool
+        Whether to include square braces in the returned string
+
+    Returns
+    -------
+    stringified_list : str
+        String representation of the input list
+
+    Example
+    -------
+    >>> get_json_list(['cat', 'dog'])
+    '["cat", "dog"]'
+
+    >>> get_json_list(['cat', 'dog'], include_brackets=False)
+    '"cat", "dog"'
+    """
     json_list = ', '.join('"%s"' % string for string in list_of_strings)
     if include_brackets:
         json_list = '[' + json_list + ']'
@@ -9,6 +36,25 @@ def get_json_list(list_of_strings, include_brackets=True):
 
 
 def get_string_from_list_of_dicts(list_of_dicts):
+    """
+    Convert a list of dicts into a flattened string representation.
+
+    Parameters
+    ---------
+    list_of_dicts : list of dict
+        Arbitrary dictionaries to convert to string
+
+    Returns
+    -------
+    stringified_dicts : str
+        String representation of the input list of dicts
+
+    Example
+    -------
+    >>> dicts = [{'a': 'this', 'b': 'that', 'c': {'the other'}}, {'d': 'then'}]
+    >>> get_string_from_list_of_dicts(dicts)
+    ' { a: "this", b: "that", c: {\'the other\'}}, { d: "then"}'
+    """
     labels_string = ''
     for d in list_of_dicts:
         labels_string += ' {'

--- a/seerpy/seerpy.py
+++ b/seerpy/seerpy.py
@@ -419,7 +419,8 @@ class SeerConnect:  # pylint: disable=too-many-public-methods
         limit : int, optional
             Batch size for repeated API calls
         search_term : str, optional
-            Filter results to study names matching this string
+            Filter results to studies that match this string on their study name,
+            study description, study code, and/or patient name
         party_id : str, optional
             The organisation/entity to specify for the query
 
@@ -1460,8 +1461,8 @@ class SeerConnect:  # pylint: disable=too-many-public-methods
     def get_diary_data_labels_dataframe(self, patient_id, label_group_id,  # pylint:disable=too-many-arguments
                              from_time=0, to_time=9e12, limit=200, offset=0):
         """
-        Get all diary study labels for a given patient and study label group as
-        a DataFrame. See `get_diary_data_labels()` for details.
+        Get all diary study labels for a given patient and diary label group,
+        returned as a DataFrame. See `get_diary_data_labels()` for details.
 
         Returns
         -------

--- a/seerpy/seerpy.py
+++ b/seerpy/seerpy.py
@@ -170,7 +170,7 @@ class SeerConnect:  # pylint: disable=too-many-public-methods
             The formatted GraphQL query
         object_name : str
             Key to retrieve from the response object, e.g. 'studies'
-        limit : int
+        limit : int, optional
             Batch size for repeated API calls
         party_id : str, optional
             The organisation/entity to specify for the query
@@ -552,7 +552,8 @@ class SeerConnect:  # pylint: disable=too-many-public-methods
 
         Parameters
         ----------
-        study_id: Seer study ID
+        study_id : str
+            Seer study ID
 
         Returns
         -------
@@ -1240,7 +1241,8 @@ class SeerConnect:  # pylint: disable=too-many-public-methods
 
         Parameters
         ----------
-        study_ids: Iterable of study IDs
+        study_ids : list of str
+            Iterable of study IDs
 
         Returns
         -------
@@ -1280,12 +1282,15 @@ class SeerConnect:  # pylint: disable=too-many-public-methods
         segment_urls : pd.DataFrame, optional
             DataFrame with columns ['segments.id', 'baseDataChunkUrl'].
             If None, these will be retrieved for each segment in `all_data`.
-        download_function: The function used to download the channel data.
-            Defaults to requests.get
-        threads: Number of threads to use. If > 1 will use multiprocessing.
-            If None (default), will use 1 on Windows and 5 on Linux/MacOS.
-        from_time: Timestamp in msec - only retrieve data after this point
-        to_time: Timestamp in msec - only retrieve data before this point
+        download_function : callable, optional
+            The function used to download the channel data. Defaults to requests.get
+        threads : int, optional
+            Number of threads to use. If > 1 will use multiprocessing. If None
+            (default), will use 1 on Windows and 5 on Linux/MacOS.
+        from_time : int, optional
+            Timestamp in msec - only retrieve data after this point
+        to_time : int, optional
+            Timestamp in msec - only retrieve data before this point
     
         Returns
         -------
@@ -1535,9 +1540,10 @@ class SeerConnect:  # pylint: disable=too-many-public-methods
 
         Parameters
         ----------
-        segments: DataFrame with cols ['dataChunks.url', 'name', 'segments.startTime']
+        segments : pd.DataFrame
+            DataFrame with columns 'dataChunks.url', 'name' & 'segments.startTime',
             as returned by `get_diary_channel_groups_dataframe()`
-        
+
         Returns
         -------
         fitbit_data_df : pd.DataFrame
@@ -1575,9 +1581,9 @@ class SeerConnect:  # pylint: disable=too-many-public-methods
         ----------
         survey_template_ids : str or list of str
             A list of survey_template_ids for which to retrieve results
-        limit : int
+        limit : int, optional
             Batch size for repeated API calls
-        offset : int
+        offset : int, optional
             Index of the first result to return
 
         Returns

--- a/seerpy/seerpy.py
+++ b/seerpy/seerpy.py
@@ -5,11 +5,19 @@ Copyright 2017 Seer Medical Pty Ltd, Inc. or its affiliates. All Rights Reserved
 
 Concepts
 --------
-- study: A period of time monitoring a patient, often with EEG/ECG
-- channel group: A type of monitoring data in a study, e.g. EEG, ECG, video
-- channel: A specific channel of a channel group, e.g. for EEG: Fz, C4, Fp1 channels
-- label group: Categories of labels relevant to a study, e.g. Abnormal / Epileptiform,
-    Normal / Routine, Sleep, Suspect - Low/Medium.
+- study: A defined period of time monitoring a patient, typically with EEG-ECG-video
+- diary: Use of the Seer app by a patient to record events such as seizures
+    ("labels") and "alerts" for medication use
+- diary study: Use of a wearable, such as a Fitbit, to record patient data
+- channel group: A mode of monitoring data, dependent on the study type.
+    Study: EEG, ECG, video
+    Diary study: Wearable data, e.g. heart rate, step count
+- channel: A channel group may have multiple channels. E.g. The different
+    electrodes for EEG: Fz, C4, Fp1 etc.
+- label group: Categories of labels relevant to a study. Depends on the study type.
+    Study: clinical annotations, e.g. Abnormal / Epileptiform, Normal / Routine
+    Diary: self-reported annotations of events, e.g. Seizure / Other
+    Diary study: labels from a wearable device, e.g. Sleep annotations
 - label: An instance of a label group. Labels typically involve the following
     fields: id, startTime, duration, timezone, note, tags, confidence,
     createdAt, createdBy
@@ -197,9 +205,9 @@ class SeerConnect:  # pylint: disable=too-many-public-methods
         Parameters
         ----------
         parent : pd.DataFrame
-            A DataFrame with f"{parent_name}id" and `child_name` cols
+            A DataFrame with f"{parent_name}id" and `child_name` columns
         parent_name : str
-            Any prefix to the 'id' and `child_name` cols in the parent DataFrame
+            Any prefix to the 'id' and `child_name` columns in the parent DataFrame
         child_name : str
             The name of the column with list of dict values
 
@@ -406,7 +414,7 @@ class SeerConnect:  # pylint: disable=too-many-public-methods
         Parameters
         ----------
         limit : int, optional
-            The number of studies to retrieve per API call
+            Batch size for repeated API calls
         search_term : str, optional
             Filter results to study names matching this string
         party_id : str, optional
@@ -474,7 +482,7 @@ class SeerConnect:  # pylint: disable=too-many-public-methods
 
         Parameters
         ----------
-        study_names : list of str
+        study_names : str or list of str
             Seer study names to retrieve
         party_id : str, optional
             The organisation/entity to specify for the query
@@ -611,7 +619,7 @@ class SeerConnect:  # pylint: disable=too-many-public-methods
         Returns
         -------
         data_chunk_df : pd.DataFrame
-            The returned DataFrame has cols:
+            The returned DataFrame has columns:
             - segments.id
             - chunkIndex
             - chunk_start
@@ -731,7 +739,8 @@ class SeerConnect:  # pylint: disable=too-many-public-methods
     def get_labels_string(self, study_id, label_group_id, from_time=0, to_time=9e12):
         """
         Get all labels for a given study and label group as an abridged string
-        representation.
+        representation. Because the GraphQL response is unvalidated, it can
+        perform significantly faster for larger datasets.
 
         Parameters
         ----------
@@ -764,7 +773,7 @@ class SeerConnect:  # pylint: disable=too-many-public-methods
         Returns
         -------
         labels_str_df : pd.DataFrame
-            Cols include 'labels.id', 'labels.startTime' and 'labels.duration'
+            Columns include 'labels.id', 'labels.startTime' and 'labels.duration'
         """
         label_results = self.get_labels_string(study_id, label_group_id, from_time=from_time,
                                                to_time=to_time)
@@ -843,7 +852,7 @@ class SeerConnect:  # pylint: disable=too-many-public-methods
         Returns
         -------
         times_df : pd.DataFrame
-            Includes cols 'id', 'startTime', 'duration' and 'user'
+            Includes columns 'id', 'startTime', 'duration' and 'user'
         """
         views = []
         while True:

--- a/seerpy/seerpy.py
+++ b/seerpy/seerpy.py
@@ -437,7 +437,8 @@ class SeerConnect:  # pylint: disable=too-many-public-methods
         limit : int
             Batch size for repeated API calls
         search_term : str
-            A string used to filter the studies returned
+            Filter results to studies including this string, either in the study
+            name or patient name. Not case sensitive.
         party_id : str
             The organisation/entity to specify for the query
 
@@ -878,34 +879,101 @@ class SeerConnect:  # pylint: disable=too-many-public-methods
         return views
 
     def get_organisations(self):
+        """
+        Get details of all available organisations.
+
+        Returns
+        -------
+        organisations : list of dict
+            Dictionaries with organisation 'id' and 'name' keys
+        """
         query_string = graphql.get_organisations_query_string()
         response = self.execute_query(query_string)['organisations']
         return response
 
     def get_organisations_dataframe(self):
+        """
+        Get details of all available organisations as a DataFrame.
+
+        Returns
+        -------
+        orgs_df : pd.DataFrame
+            Organisations DataFrame with 'id' and 'name' columns
+        """
         orgs = self.get_organisations()
         if orgs is None:
             return orgs
         return pd.DataFrame(orgs)
 
     def get_patients(self, party_id=None):
+        """
+        Get available patient IDs and user names.
+
+        Parameters
+        ----------
+        party_id : str, optional
+            The organisation/entity to specify for the query
+
+        Returns
+        -------
+        patients : list of dict
+            Patient details, with keys 'id' and 'user'
+        """
         query_string = graphql.get_patients_query_string()
         response = self.execute_query(query_string, party_id)['patients']
         return response
 
     def get_patients_dataframe(self, party_id=None):
+        """
+        Get available patient IDs and user names as a DataFrame.
+
+        Parameters
+        ----------
+        party_id : str, optional
+            The organisation/entity to specify for the query
+
+        Returns
+        -------
+        patient_df : pd.DataFrame
+            Patient details, with columns 'id' and 'user'
+        """
         patients = self.get_patients(party_id)
         if patients is None:
             return patients
         return json_normalize(patients).sort_index(axis=1)
 
     def get_documents_for_studies(self, study_ids, limit=50):
+        """
+        Get details of all documents associated with given study ID(s). 
+
+        Parameters
+        ----------
+        study_id : str or list of str
+            Iterable of Seer study ID
+        limit : int, optional
+            Batch size for repeated API calls
+
+        Returns
+        -------
+        documents : list of dict
+            Document details. Dict has key 'documents' that indexes a nested dict
+            with keys including: 'id', 'name', 'fileSize', 'downloadFileUrl'
+        """
         if isinstance(study_ids, str):
             study_ids = [study_ids]
         documents_query_string = graphql.get_documents_for_study_ids_paged_query_string(study_ids)
         return self.get_paginated_response(documents_query_string, 'studies', limit)
 
     def get_documents_for_studies_dataframe(self, study_ids, limit=50):
+        """
+        Get details of all documents associated with given study ID(s) as a DataFrame.
+        See `get_documents_for_studies()` for details.
+
+        Returns
+        -------
+        documents_df : pd.DataFrame
+            DataFrame with document details for a study
+        """
         documents = []
         for study in self.get_documents_for_studies(study_ids, limit):
             for document in study['documents']:
@@ -918,38 +986,37 @@ class SeerConnect:  # pylint: disable=too-many-public-methods
 
     def get_diary_labels(self, patient_id, label_type='all', offset=0, limit=100, from_time=0, to_time=9e12, from_duration=0, to_duration=9e12):
         """
-        Retrieves diary label groups and labels for a given patient.
+        Retrieve diary label groups and labels for a given patient.
 
         Parameters
         ----------
-        patient_id: str
-                Seer patient ID
-        label_type: str
-                The type of label to retrieve. Default = 'all'. Options = 'seizure',
-                'medications', 'cardiac'.
-        offset: int
-                Index of first record to return
-        limit: int
-                Batch size for repeated API calls
-        from_time: int
-                UTC timestamp to apply a range filter on label start times.
-                Retrieves labels after the given from_time
-        to_time: int
-                UTC timestamp to apply a range filter label start times.
-                Retrieves labels before the given to_time
-        from_duration: int
-                Time in millseconds to apply a range filter on the duration of labels.
-                Retrieves labels of duration > from_duration
-        to_duration: int
-                Time in milliseconds to apply a range filter on the duration of labels.
-                Retrieves labels of duration < to_duration
+        patient_id : str
+            Seer patient ID
+        label_type : str, optional
+            The type of label to retrieve. Default = 'all'. Options = 'seizure',
+            'medications', 'cardiac'.
+        offset : int, optional
+            Index of first record to return
+        limit : int, optional
+            Batch size for repeated API calls
+        from_time : int, optional
+            UTC timestamp to apply a range filter on label start times.
+            Retrieves labels after the given from_time
+        to_time : int, optional
+            UTC timestamp to apply a range filter label start times.
+            Retrieves labels before the given to_time
+        from_duration : int, optional
+            Time in millseconds to apply a range filter on the duration of labels.
+            Retrieves labels of duration > from_duration
+        to_duration : int, optional
+            Time in milliseconds to apply a range filter on the duration of labels.
+            Retrieves labels of duration < to_duration
 
         Returns
         -------
-        label_results: dict
-                Returns a dict with keys 'id' and 'labelGroups'; 'labelGroups' indexes
-                to a list of dict with keys ['id', 'labelType', 'name', 'labels',
-                'numberOfLabels', 'labelSourceType']
+        label_results : dict
+            Returns a dictionary with a 'labelGroups' key that indexes to a list
+            of dictionaries including keys 'labelType', 'name', 'labels', 'numberOfLabels' etc.
         """
         label_results = None
         # set true if we need to fetch labels
@@ -988,7 +1055,15 @@ class SeerConnect:  # pylint: disable=too-many-public-methods
         return label_results
 
     def get_diary_labels_dataframe(self, patient_id, label_type='all', offset=0, limit=100, from_time=0, to_time=9e12, from_duration=0, to_duration=9e12):
+        """
+        Get all diary label groups and labels for a given patient as a DataFrame.
+        See `get_diary_labels()` for details.
 
+        Returns
+        -------
+        diary_labels_df : pd.DataFrame
+            DataFrame with diary label information
+        """
         label_results = self.get_diary_labels(patient_id, label_type, offset, limit, from_time, to_time, from_duration, to_duration)
         if label_results is None:
             return label_results
@@ -1006,11 +1081,39 @@ class SeerConnect:  # pylint: disable=too-many-public-methods
         return label_groups
 
     def get_diary_medication_alerts(self, patient_id, from_time=0, to_time=9e12):
+        """
+        Get diary medications ("alerts") for a given patient.
+
+        Parameters
+        ----------
+        patient_id : str
+            The Seer patient ID for which to retrieve diary labels
+        from_time : int, optional
+            Timestamp in msec - only retrieve data after this point
+        to_time : int, optional
+            Timestamp in msec - only retrieve data before this point
+
+        Returns
+        -------
+        medications : dict
+            Medication information with key 'alerts', which indexes to a dictionary
+             with a 'labels' key that indexes list of dict with keys 'doses',
+             'alert', 'startTime', 'scheduledTime' etc.
+        """
         query_string = graphql.get_diary_medication_alerts_query_string(patient_id, from_time, to_time)
         response = self.execute_query(query_string)['patient']['diary']
         return response
 
     def get_diary_medication_alerts_dataframe(self, patient_id, from_time=0, to_time=9e12):
+        """
+        Get diary medication alerts for a given patient as a DataFrame. See
+        `get_diary_medication_alerts()` for details.
+
+        Returns
+        -------
+        medications_df : pd.DataFrame
+            DataFrame with details of patient medication information
+        """
         results = self.get_diary_medication_alerts(patient_id, from_time, to_time)
         if results is None:
             return results
@@ -1019,11 +1122,38 @@ class SeerConnect:  # pylint: disable=too-many-public-methods
         return labels
 
     def get_diary_medication_compliance(self, patient_id, from_time=0, to_time=0):
+        """
+        Get all medication compliance records for a given patient.
+
+        Parameters
+        ----------
+        patient_id : str
+            The Seer patient ID for which to retrieve diary labels
+        from_time : int, optional
+            Timestamp in msec - only retrieve data after this point
+        to_time : int, optional
+            Timestamp in msec - only retrieve data before this point
+
+        Returns
+        -------
+        medication_compliance : dict
+            Has a single key, 'patient', which indexes a nested dictionary with a
+            'diary' key, which indexes a dictionary with a 'medicationCompliance' key.
+        """
         query_string = graphql.get_diary_medication_compliance_query_string(patient_id, from_time, to_time)
         response = self.execute_query(query_string)
         return response
 
     def get_diary_medication_compliance_dataframe(self, patient_id, from_time=0, to_time=0):
+        """
+        Get all medication compliance records for a given patient as a DataFrame.
+        See `get_diary_medication_compliance()` for details.
+
+        Returns
+        -------
+        medication_compliance_df : pd.DataFrame
+            Dataframe with columns about medication compliance
+        """
         results = self.get_diary_medication_compliance(patient_id, from_time, to_time)
         if results is None:
             return results
@@ -1033,22 +1163,22 @@ class SeerConnect:  # pylint: disable=too-many-public-methods
         return medication_compliance
 
     def get_all_study_metadata_by_names(self, study_names=None, party_id=None):
-        """Get all the metadata available about named studies
+        """
+        Get all metadata available about provided study names. See
+        `get_all_study_metadata_by_ids()` for details.
 
         Parameters
         ----------
-        study_names (Optional) : a list of study names. If not provided, data will be returned for
-        all studies
-        party_id (Optional) : string, the party id of the context for the query (e.g. organisation)
+        study_names : str or list of str, optional
+            Study names. If not provided, data will be returned for all studies
+        party_id : str, optional
+            The organisation/entity to specify for the query
 
         Returns
         -------
-        allData : dict
-                a dictionary with a single key 'studies' with a list of studies as it's value
-
-        Example
-        -------
-        studies = get_all_study_metadata_by_names()['studies']
+        metadata : dict
+            Nested dictionaries with information on patient, channel groups,
+            channels and segments
         """
         study_ids = None
         if study_names:
@@ -1056,21 +1186,22 @@ class SeerConnect:  # pylint: disable=too-many-public-methods
         return self.get_all_study_metadata_by_ids(study_ids)
 
     def get_all_study_metadata_by_ids(self, study_ids=None):
-        """Get all the metadata available about studies with the suppled ids
+        """
+        Get all metadata available about studies with supplied IDs.
 
         Parameters
         ----------
-        study_ids (Optional) : a list of study ids. If not provided, data will be returned for
-        all studies
+        study_ids : list of str, optional
+            A list of study IDs. If not provided, data will be returned for all
+            available studies.
 
         Returns
         -------
-        allData : dict
-                a dictionary with a single key 'studies' with a list of studies as it's value
-
-        Example
-        -------
-        studies = get_all_study_metadata_by_ids()['studies']
+        metadata : dict
+            A dictionary with a single key 'studies', which indexes a list of
+            dictionaries with keys 'id', 'name', 'description', 'patient' and
+            'channelGroups'. 'channelGroup' indexes a dictionary with keys
+            'channels', 'segments', 'sampleRate' etc.
         """
         if study_ids is None:
             study_ids = self.get_study_ids()
@@ -1083,12 +1214,39 @@ class SeerConnect:  # pylint: disable=too-many-public-methods
         return {'studies' : result}
 
     def get_all_study_metadata_dataframe_by_names(self, study_names=None):
+        """
+        Get all metadata available about studies with the suppled names as a
+        DataFrame. See `get_all_study_metadata_by_ids()` for details.
+
+        Parameters
+        ----------
+        study_names : str or list of str, optional
+            Study names. If not provided, data will be returned for all studies
+
+        Returns
+        -------
+        metadata_df : pd.DataFrame
+            DataFrame with information on patient, channel groups, channels and segments
+        """
         study_ids = None
         if study_names:
             study_ids = self.get_study_ids_from_names(study_names)
         return self.get_all_study_metadata_dataframe_by_ids(study_ids)
 
     def get_all_study_metadata_dataframe_by_ids(self, study_ids=None):
+        """
+        Get all metadata available about studies with the suppled IDs as a
+        DataFrame. See `get_all_study_metadata_by_ids()` for more details.
+
+        Parameters
+        ----------
+        study_ids: Iterable of study IDs
+
+        Returns
+        -------
+        metadata_df : pd.DataFrame
+            DataFrame with information on patient, channel groups, channels and segments
+        """
         metadata = self.get_all_study_metadata_by_ids(study_ids)
         all_data = json_normalize(metadata['studies']).sort_index(axis=1)
         channel_groups = self.pandas_flatten(all_data, '', 'channelGroups')
@@ -1111,30 +1269,37 @@ class SeerConnect:  # pylint: disable=too-many-public-methods
     # pylint:disable=too-many-locals
     def get_channel_data(self, all_data, segment_urls=None,  # pylint:disable=too-many-arguments
                          download_function=requests.get, threads=None, from_time=0, to_time=9e12):
-        """Download data chunks and stich them together in one dataframe
+        """
+        Download raw data for all channel groups and segments listed in a given
+        metadata DataFrame and wrangle into a new DataFrame.
 
         Parameters
         ----------
-        all_data : pandas DataFrame
-                metadata required for downloading and processing raw data
-        segment_urls : pandas DataFrame
-                columns=['segments.id', 'baseDataChunkUrl']
-                if None, these will be retrieved for each segment in all_data
-        download_function: function
-                the function used to download the channel data. defaults to requests.get
-        threads : int
-                number of threads to use. If > 1 then will use multiprocessing
-                if None (default), it will use 1 on Windows and 5 on Linux/MacOS
-
+        all_data : pd.DataFrame
+            Study metadata, as returned by `get_all_study_metadata_dataframe_by_*()`
+        segment_urls : pd.DataFrame, optional
+            DataFrame with columns ['segments.id', 'baseDataChunkUrl'].
+            If None, these will be retrieved for each segment in `all_data`.
+        download_function: The function used to download the channel data.
+            Defaults to requests.get
+        threads: Number of threads to use. If > 1 will use multiprocessing.
+            If None (default), will use 1 on Windows and 5 on Linux/MacOS.
+        from_time: Timestamp in msec - only retrieve data after this point
+        to_time: Timestamp in msec - only retrieve data before this point
+    
         Returns
         -------
-        data : pandas DataFrame
-                dataframe containing studyID, channelGroupIDs, semgmentIDs, time, and raw data
+        data_df : pd.DataFrame
+            DataFrame with 'time', 'id', 'channelGroups.id' and 'segments.id' columns,
+            as well as a column for each data channel, e.g. each EEG electrode.
 
         Example
         -------
-        data = get_channel_data(all_data)
-
+        Get all ECG data for a study of patient "Jane Doe":
+        >>> study_id = get_study_ids(search_term="Jane Doe")[0]['id']
+        >>> metadata_df = get_all_study_metadata_dataframe_by_ids(study_id)
+        >>> ecg_metadata_df = metadata_df[metadata_df['channelGroups.name'] == 'ECG']
+        >>> ecg_data_df = get_channel_data(ecg_metadata_df)
         """
         if segment_urls is None:
             segment_ids = all_data['segments.id'].drop_duplicates().tolist()
@@ -1144,11 +1309,48 @@ class SeerConnect:  # pylint: disable=too-many-public-methods
                                       to_time)
 
     def get_all_bookings(self, organisation_id, start_time, end_time):
+        """
+        Get all bookings for any studies that are active at any point between
+        `start_time` and `end_time`.
+
+        Parameters
+        ----------
+        organisation_id : str
+            Organisation ID associated with patient bookings
+        start_time : int
+            Timestamp in msec - find studies active after this point
+        end_time : int
+            Timestamp in msec - find studies active before this point
+
+        Returns
+        -------
+        bookings : list of dict
+            Booking information, with keys including 'id', 'startTime', 'endTime',
+            'patient', 'referral', 'equipmentItems', and 'location'
+        """
         query_string = graphql.get_bookings_query_string(organisation_id, start_time, end_time)
         response = self.execute_query(query_string)
         return response['organisation']['bookings']
 
     def get_all_bookings_dataframe(self, organisation_id, start_time, end_time):
+        """
+        Get all bookings for any studies that are active at any point between
+        `start_time` and `end_time` as a DataFrame. See `get_all_bookings()`.
+
+        Parameters
+        ----------
+        organisation_id : str
+            Organisation ID associated with patient bookings
+        start_time : int
+            Timestamp in msec - find studies active after this point
+        end_time : int
+            Timestamp in msec - find studies active before this point
+        
+        Returns
+        -------
+        bookings_df : pd.DataFrame
+            DataFrame with details about all relevant bookings
+        """
         bookings_response = self.get_all_bookings(organisation_id, start_time, end_time)
         bookings = json_normalize(bookings_response).sort_index(axis=1)
         studies = self.pandas_flatten(bookings, 'patient.', 'studies')
@@ -1161,6 +1363,24 @@ class SeerConnect:  # pylint: disable=too-many-public-methods
 
     # DIARY STUDY (FITBIT) ANALYSIS
     def get_diary_data_groups(self, patient_id, limit=20, offset=0):
+        """
+        Get wearable label groups (e.g. heart rate, steps) for a patient diary study.
+
+        Parameters
+        ----------
+        patient_id : str
+            The Seer patient ID for which to retrieve diary data
+        limit : int, optional
+            The maximum number of results to return
+        offset : int optional
+            The index of the first label group to return. Useful in conjunction
+            with `limit` for repeated calls
+
+        Returns
+        -------
+        label_groups : list of dict
+            Diary study label groups, with keys 'id', 'name', 'numberOfLabels'
+        """
         # TODO use limit/offset for pagination (unlikely to be more than 20 label groups for a while)
         query_string = graphql.get_diary_study_label_groups_string(patient_id, limit, offset)
         response = self.execute_query(query_string)['patient']['diaryStudy']
@@ -1168,21 +1388,14 @@ class SeerConnect:  # pylint: disable=too-many-public-methods
         return label_groups
 
     def get_diary_data_groups_dataframe(self, patient_id, limit=20, offset=0):
-        """Get a list of label groups present in a patient's diary study
-
-        Parameters
-        ----------
-        patient_id : The patient ID (string)
+        """
+        Get wearable label groups (e.g. heart rate, steps) for a patient diary
+        study as a DataFrame. See `get_diary_data_groups()` for details.
 
         Returns
         -------
-        label_groups : pandas DataFrame
-                dataframe containing labelGroupID, labelGroupName, numberOfLabels in labelGroup
-
-        Example
-        -------
-        label_groups = get_diary_study_label_groups_dataframe("some_id")
-
+        label_groups : pd.DataFrame
+            Dataframe of diary study label groups
         """
         label_group_results = self.get_diary_data_groups(patient_id, limit, offset)
         if label_group_results is None:
@@ -1192,6 +1405,31 @@ class SeerConnect:  # pylint: disable=too-many-public-methods
 
     def get_diary_data_labels(self, patient_id, label_group_id, from_time=0,  # pylint:disable=too-many-arguments
                    to_time=9e12, limit=200, offset=0):
+        """
+        Get all diary study labels for a given patient and wearable label group,
+        e.g. heart rate.
+
+        Parameters
+        ----------
+        patient_id : str
+            The Seer patient ID for which to retrieve diary labels
+        label_group_id : str
+            The ID of the diary study label group for which to retrieve labels
+        from_time : int, optional
+            Timestamp in msec - find diary labels after this point
+        to_time : int, optional
+            Timestamp in msec - find diary labels before this point
+        limit : int, optional
+            Batch size for repeated API calls
+        offset : int, optional
+            The index of the first label group to return
+
+        Returns
+        -------
+        data_labels : dict
+            A dict with one key, 'labelGroup', which indexes to a dict with
+        a 'labels' key. Labels include ['id', 'startTime', 'duration', 'tags', 'timezone']
+        """
         label_results = None
 
         while True:
@@ -1213,24 +1451,15 @@ class SeerConnect:  # pylint: disable=too-many-public-methods
 
     def get_diary_data_labels_dataframe(self, patient_id, label_group_id,  # pylint:disable=too-many-arguments
                              from_time=0, to_time=9e12, limit=200, offset=0):
-        """Get labels from a patient's diary study
-
-        Parameters
-        ----------
-        patient_id : The patient ID (string)
-        label_group_id: The label group ID
-        from_time: min start time for labels (UTC time in milliseconds)
-        to_time: max start time for labels (UTC time in milliseconds)
+        """
+        Get all diary study labels for a given patient and wearble label group
+        as a DataFrame.
+        See `get_diary_data_labels()` for details.
 
         Returns
         -------
-        label_group : pandas DataFrame
-                dataframe containing labelGroup info, labels (startTime, timeZone, duration) and tags
-
-        Example
-        -------
-        label_groups = get_diary_study_labels_dataframe(patient_id, label_group_id)
-
+        data_labels_df : pd.DataFrame
+            DataFrame with information about labels for a diary study
         """
         label_results = self.get_diary_data_labels(patient_id, label_group_id, from_time, to_time, limit, offset)
         if label_results is None:
@@ -1249,11 +1478,38 @@ class SeerConnect:  # pylint: disable=too-many-public-methods
 
 
     def get_diary_channel_groups(self, patient_id, from_time, to_time):
+        """
+        Get all diary study channel groups (e.g. heart rate) and associated
+        segment information for a given patient.
+
+        Parameters
+        ----------
+        patient_id : str
+            The Seer patient ID for which to retrieve diary channel groups
+        from_time : int
+            Timestamp in msec - find segments after this point
+        to_time : int
+            Timestamp in msec - find segments before this point
+
+        Returns
+        -------
+        diary_channel_groups : list of dicts
+            Diary channel group details, with keys 'id', 'name', 'startTime', 'segments'
+        """
         query_string = graphql.get_diary_study_channel_groups_query_string(patient_id, from_time, to_time)
         response = self.execute_query(query_string)
         return response['patient']['diaryStudy']['channelGroups']
 
-    def get_diary_channel_groups_dataframe(self, patient_id, from_time=0, to_time=90000000000000):
+    def get_diary_channel_groups_dataframe(self, patient_id, from_time=0, to_time=9e13):
+        """
+        Get all diary study channel groups and associated segment information for a given
+        patient, as a DataFrame. See `get_diary_channel_groups()` for details.
+
+        Returns
+        -------
+        diary_channel_groups_df : pd.DataFrame
+            Diary channel groups with columns 'id', 'name', 'startTime', 'segments'
+        """
         metadata = self.get_diary_channel_groups(patient_id, from_time, to_time)
         channel_groups = json_normalize(metadata).sort_index(axis=1)
         if channel_groups.empty:
@@ -1272,15 +1528,20 @@ class SeerConnect:  # pylint: disable=too-many-public-methods
 
 
     def get_diary_fitbit_data(self, segments):
-        """Get fitbit data from a patient's diary study
+        """
+        Get Fitbit data from a patient diary study. `segments` should be a
+        DataFrame as returned by `get_diary_channel_groups_dataframe()` that
+        includes columns ['dataChunks.url', 'name', 'segments.startTime'].
 
         Parameters
         ----------
-        segments: pandas DataFrame as returned by get_diary_channel_groups_dataframe
-
+        segments: DataFrame with cols ['dataChunks.url', 'name', 'segments.startTime']
+            as returned by `get_diary_channel_groups_dataframe()`
+        
         Returns
         -------
-        data: pandas DataFrame containing timestamp (adjusted), value, and group name
+        fitbit_data_df : pd.DataFrame
+            Fitbit data DataFrame with timestamp (adjusted), value, and group name
 
         """
         segment_urls = segments['dataChunks.url']
@@ -1307,22 +1568,25 @@ class SeerConnect:  # pylint: disable=too-many-public-methods
         return data
 
     def get_mood_survey_results(self, survey_template_ids, limit=200, offset=0):
-        """Gets a list of dictionaries containing mood survey results
+        """
+        Get mood survey results for one or more survey template IDs.
 
         Parameters
         ----------
-        survey_template_ids : A list of survey_template_ids to retrieve results for
+        survey_template_ids : str or list of str
+            A list of survey_template_ids for which to retrieve results
+        limit : int
+            Batch size for repeated API calls
+        offset : int
+            Index of the first result to return
 
         Returns
         -------
-        mood_survey_results : a list of dictionaries
-                a list of dictionaries containing survey result data
-
-        Example
-        -------
-        survey_results = get_mood_survey_results("some_id")
+        mood_survey_results : list of dict
+            A list of dictionaries with survey result data, including keys
+            'completer', 'lastSubmittedAt', and 'fields', which indexes to a
+            list of dictionaries with keys 'key' and 'value'
         """
-
         current_offset = offset
         results = []
 
@@ -1342,20 +1606,14 @@ class SeerConnect:  # pylint: disable=too-many-public-methods
 
 
     def get_mood_survey_results_dataframe(self, survey_template_ids, limit=200, offset=0):
-        """Gets a dataframe containing mood survey results
-
-        Parameters
-        ----------
-        survey_template_ids : A list of survey_template_ids to retrieve results for
+        """
+        Get mood survey results as a DataFrame. See `get_mood_survey_results()`
+        for details.
 
         Returns
         -------
-        mood_survey_results : pandas DataFrame
-            dataframe with survey.id, survey.lastSubmittedAt, surveyField.key, surveyField.value
-
-        Example
-        -------
-        survey_results = get_mood_survey_results_dataframe("some_id")
+        mood_survey_results : pd.DataFrame
+            Dataframe with survey.id, survey.lastSubmittedAt, surveyField.key, surveyField.value
         """
 
         results = self.get_mood_survey_results(survey_template_ids, limit, offset)
@@ -1371,19 +1629,23 @@ class SeerConnect:  # pylint: disable=too-many-public-methods
         return surveys
 
     def get_study_ids_in_study_cohort(self, study_cohort_id, limit=200, offset=0):
-        """Gets the IDs of studies in the given StudyCohort
+        """
+        Get the IDs of studies in a given study cohort.
 
         Parameters
         ----------
-        study_cohort_id: the id of StudyCohort to retrieve
-        page_size: the number of records to return per page (optional)
-        offset: the query offset
+        study_cohort_id : str
+            The study cohort ID to retrieve
+        limit : int, optional
+            Batch size for repeated API calls
+        offset : int, optional
+            Index of the first result to return
 
         Returns
         -------
-        data: a list of Study ids that are in the StudyCohort
+        study_ids : list of str
+            All study IDs in the given cohort
         """
-
         current_offset = offset
         results = []
         while True:
@@ -1400,78 +1662,87 @@ class SeerConnect:  # pylint: disable=too-many-public-methods
         return results
 
     def create_study_cohort(self, name, description=None, key=None, study_ids=None):
-        """Creates a new study cohort
+        """
+        Create a new study cohort.
 
         Parameters
         ----------
-        name: string
+        name : str
             The name of the study cohort to create
-        description: string, optional
+        description : str, optional
             An optional description of the study cohort
-        key: string, optional
+        key: str, optional
             An optional key to describe the cohort. Defaults to the ID
-        study_ids: list of strings
-            A list of study Ids to add to the study cohort
+        study_ids: list of str, optional
+            A list of study IDs to add to the study cohort
 
         Returns
         -------
-        The study cohort id
+        cohort_id : str
+            The study cohort ID
         """
         query_string = graphql.create_study_cohort_mutation_string(
             name, description, key, study_ids)
         return self.execute_query(query_string)
 
     def add_studies_to_study_cohort(self, study_cohort_id, study_ids):
-        """Add studies to a study cohort by ID
+        """
+        Add studies to a study cohort by ID.
 
         Parameters
         ----------
-        study_cohort_id: string
+        study_cohort_id : str
             The ID of the study cohort to modify
-        study_ids: list of strings
+        study_ids : list of str
             A list of study IDs to add to the study cohort
 
         Returns
         -------
-        The study cohort id
+        cohort_id : str
+            The study cohort ID
         """
         query_string = graphql.add_studies_to_study_cohort_mutation_string(
             study_cohort_id, study_ids)
         return self.execute_query(query_string)
 
-
     def remove_studies_from_study_cohort(self, study_cohort_id, study_ids):
-        """Remove studies from a study cohort by ID
+        """
+        Remove studies from a study cohort by ID.
 
         Parameters
         ----------
-        study_cohort_id: string
+        study_cohort_id : str
             The ID of the study cohort to modify
-        study_ids: list of strings
+        study_ids : list of str
             A list of study IDs to remove from the study cohort
 
         Returns
         -------
-        The study cohort id
+        cohort_id : str
+            The study cohort ID
         """
         query_string = graphql.remove_studies_from_study_cohort_mutation_string(
             study_cohort_id, study_ids)
         return self.execute_query(query_string)
 
     def get_user_ids_in_user_cohort(self, user_cohort_id, limit=200, offset=0):
-        """Gets the IDs of users in the given UserCohort
+        """
+        Get the IDs of users in the given user cohort.
 
         Parameters
         ----------
-        user_cohort_id: the id of UserCohort to retrieve
-        page_size: the number of records to return per page (optional)
-        offset: the query offset
+        user_cohort_id : str
+            ID of the user cohort to retrieve
+        limit : int, optional
+            Batch size for repeated API calls
+        offset : int, optional
+            Index of the first result to return
 
         Returns
         -------
-        data: a list of User ids that are in the UserCohort
+        user_ids : list of str
+            User IDs that are in the cohort
         """
-
         current_offset = offset
         results = []
         while True:
@@ -1488,59 +1759,64 @@ class SeerConnect:  # pylint: disable=too-many-public-methods
         return results
 
     def create_user_cohort(self, name, description=None, key=None, user_ids=None):
-        """Creates a new UserCohort
+        """
+        Create a new user cohort.
 
         Parameters
         ----------
-        name: string
+        name : str
             The name of the user cohort to create
-        description: string, optional
+        description : str, optional
             An optional description of the user cohort
-        key: string, optional
+        key : str, optional
             An optional key to describe the cohort. Defaults to the ID
-        user_ids: list of strings
-            A list of user Ids to add to the user cohort
+        user_ids : list of str
+            A list of user IDs to add to the user cohort
 
         Returns
         -------
-        The user cohort id
+        cohort_id : str
+            The user cohort ID
         """
         query_string = graphql.get_create_user_cohort_mutation_string(
             name, description, key, user_ids)
         return self.execute_query(query_string)
 
     def add_users_to_user_cohort(self, user_cohort_id, user_ids):
-        """Add users to a user cohort by ID
+        """
+        Add users to a user cohort by ID.
 
         Parameters
         ----------
-        user_cohort_id: string
+        user_cohort_id : str
             The ID of the user cohort to modify
-        user_ids: list of strings
+        user_ids : list of str
             A list of user IDs to add to the user cohort
 
         Returns
         -------
-        The user cohort id
+        cohort_id : str
+            The user cohort ID
         """
         query_string = graphql.get_add_users_to_user_cohort_mutation_string(
             user_cohort_id, user_ids)
         return self.execute_query(query_string)
 
-
     def remove_users_from_user_cohort(self, user_cohort_id, user_ids):
-        """Remove users from a user cohort by ID
+        """
+        Remove users from a user cohort by ID
 
         Parameters
         ----------
-        user_cohort_id: string
+        user_cohort_id : str
             The ID of the user cohort to modify
-        user_ids: list of strings
+        user_ids : list of str
             A list of user IDs to remove from the user cohort
 
         Returns
         -------
-        The user cohort id
+        cohort_id : str
+            The user cohort ID
         """
         query_string = graphql.get_remove_users_from_user_cohort_mutation_string(
             user_cohort_id, user_ids)

--- a/seerpy/utils.py
+++ b/seerpy/utils.py
@@ -180,7 +180,7 @@ def create_data_chunk_urls(metadata, segment_urls, from_time=0, to_time=9e12):
 def get_channel_data(all_data, segment_urls,  # pylint:disable=too-many-arguments
                      download_function=requests.get, threads=None, from_time=0, to_time=9e12):
     """
-    Download data chunks and stich together into a single DataFrame.
+    Download data chunks and stitch together into a single DataFrame.
 
     Parameters
     ----------
@@ -195,9 +195,9 @@ def get_channel_data(all_data, segment_urls,  # pylint:disable=too-many-argument
         Number of threads to use. If > 1 then will use multiprocessing. If None
         (default), it will use 1 on Windows and 5 on Linux/MacOS
     from_time : int, optional
-        Timestamp in msec - only retrieve data after this point
+        Timestamp in msec - only retrieve data from this point onward
     to_time : int, optional
-        Timestamp in msec - only retrieve data before this point
+        Timestamp in msec - only retrieve data up until this point
 
     Returns
     -------
@@ -268,7 +268,7 @@ def get_channel_data(all_data, segment_urls,  # pylint:disable=too-many-argument
 
 def get_channel_names_or_ids(metadata):
     """
-    Get a list of unique channel names, or IDs where name is null or duplicated.
+    Get a list of unique channel names, using ID instead if a name is null or duplicated.
 
     Parameters
     ----------
@@ -380,7 +380,7 @@ def plot_eeg(x, y=None, pred=None, squeeze=5.0, scaling_factor=None):
 
 def butter_bandstop(lowcut, highcut, fs, order=5):
     """
-    Get second-order-sections representation of and IIR Butterworth digital
+    Get second-order-sections representation of an IIR Butterworth digital
     bandstop filter.
 
     Parameters
@@ -437,7 +437,7 @@ def butter_bandstop_filter(data, lowcut, highcut, fs, order=5):
 
 def butter_bandpass(lowcut, highcut, fs, order=5):
     """
-    Get second-order-sections representation of and IIR Butterworth digital
+    Get second-order-sections representation of an IIR Butterworth digital
     bandpass filter.
 
     Parameters
@@ -494,8 +494,8 @@ def butter_bandpass_filter(data, lowcut, highcut, fs, order=5):
 
 def get_diary_fitbit_data(data_url):
     """
-    Download Fitbit data from a given URL and wrangle into a DataFrame.
-    
+    Download Fitbit data from a given URL and return as a DataFrame.
+
     Parameters
     ----------
     data_url : str


### PR DESCRIPTION
Add/update docstrings for all functions. This replaces [PR 58](https://github.com/seermedical/seer-py/pull/58), which had a bit much going on, and this PR *only* adds/modifies docstrings. Attempted to adhere to Numpy style as much as possible, i.e.:

```
def some_function(param1, param2, param2=5.0):
    """
    <Imperative tense description of function.>

    Parameters
    ----------
    param1 : str
        Short description of expected data type
    param2 : int or float
        Short description
    param3 : float, optional
        Short description

    Returns
    -------
    return_name : bool
        Short description of return value

    Example
    -------
    >>> call_function(val1, val2)
    # expected output
    """
```

- Includes a "Parameters" and "Returns" section for almost every function in _seerpy.py_ and _utils.py_, except for a few functions that have a lot of parameters and a sibling function, in which case it may say "refer to <sibling function> for details" in lieu of duplicating the "Parameters" section.
- Remove all "Notes" and "Example" sections that are either blank or trivial, e.g. `result = function(val1, val2)`
- Incorporated all feedback from Will and Pip for the last PR

Included examples for the following functions, which may be challenging to reason about:
- seerpy. pandas_flatten
- seerpy.get_channel_data
- graphql.get_json_list
- graphql.get_string_from_list_of_dicts
- utils.plot_eeg
- utils.quote_str

Happy to have feedback on any of the above and make changes.