### PR TITLE
Refactor auth into separate, reusable classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,8 @@ at https://app.seermedical.com/. You can then use seer-py to authenticate with
 the API.
 
 seer-py will prompt for the username and password that you use to log in to the
-The simplest way to authenticate is to create an instance of `SeerConnect`.
-Seer App.
+Seer App. The simplest way to authenticate is to create an instance of
+`SeerConnect`:
 
 ```
 from seerpy import SeerConnect

--- a/README.md
+++ b/README.md
@@ -32,32 +32,52 @@ To start a Jupyter notebook, run `jupyter notebook` in a command/bash window. Fu
 
 ## Authenticating
 
-To access data from the Seer platform you must first register for an account 
+To access data from the Seer platform you must first register for an account
 at https://app.seermedical.com/. You can then use seer-py to authenticate with
 the API.
 
-Create an instance of the `SeerAuth` class (defined in _auth.py_) and provide
-your email address and password using one of the following options:
+seer-py will prompt for the username and password that you use to log in to the
+The simplest way to authenticate is to create an instance of `SeerConnect`.
+Seer App.
 
-1. Pass them as arguments when instantiating the `SeerAuth` object.
-2. In your home directory, create a  _.seerpy/_ folder, and within it a file
-  named _credentials_. Save your email address on the first line and your
-  password on the second line with no other text.
-3. If you don't use one of the previous options, you will be prompted for your
-  email address and password in the terminal or Jupyter notebook before you can
-  retrieve any data.
+```
+from seerpy import SeerConnect
+
+client = SeerConnect()
+```
+
+Alternatively, you can provide your `email` and `password` as arguments
+`SeerConnect`
+
+```
+client = SeerConnect(email='user@website.com', password='....')
+```
+
+You can also store your credentials by creating a _.seerpy/_ folder in your home
+directory. Within the folder, create a file named _credentials_. Save your email
+address on the first line and your password on the second line with no other
+text. You can then call SeerConnect as above:
+
+```
+client = SeerConnect()
+```
 
 ## Running with other API endpoints
 
-To run seer-py against other environments (for instance against a development API server), perform the following steps:
+To run seer-py in other environments (for instance against a development
+API server), then you can use one of the preconfigured authentication methods:
 
-1. Run the `seer-api` server following the relevant documentation in the API repository
-2. Run a `seer-graphiql` server (which includes the required proxies), ensuring that `HTTPS` is set to `OFF` in the startup script,
-3. Call `SeerConnect` with the alternative endpoint, and setting `dev` to `True`. For example:
-
-```python
-client = SeerConnect(api_url='http://localhost:3090/api/development', dev=True)
 ```
+from seerpy import auth, SeerConnect
+client = SeerConnect(auth=auth.SeerDevAuth('http://localhost:8000'))
+```
+
+When running an API server locally, you may also need to:
+
+1. Run the `seer-api` server following the relevant documentation in the API
+   repository
+2. Run a `seer-graphiql` server (which includes the required proxies), ensuring
+   that `HTTPS` is set to `OFF` in the startup script
 
 ## Troubleshooting
 

--- a/seerpy/auth.py
+++ b/seerpy/auth.py
@@ -43,18 +43,15 @@ class SeerAuth(BaseAuth):
 
     def __init__(
             self,
-            api_url,
+            api_url=None,
             email=None,
             password=None,
-            region='',
             cookie_key=DEFAULT_COOKIE_KEY,
             credential_namespace='cookie'):
 
-        # default to no region unless specified
-        use_region = region if len(region) > 0 and region.lower() != 'au' else ''
-
         super(SeerAuth, self).__init__(
-            api_url if api_url is not None else f"https://api{use_region}.seermedical.com/api"
+            api_url if api_url is not None \
+                else f"https://api.seermedical.com/api"
         )
 
         self.cookie = None
@@ -156,7 +153,8 @@ class SeerAuth(BaseAuth):
             self.email = input('Email Address: ')
             self.password = getpass.getpass('Password: ')
             if not self.help_message_displayed:
-                print(f"\nHint: To skip this in future, save your details to {pswdfile}")
+                print(
+                    f"\nHint: To skip this in future, save your details to {pswdfile}")
                 print("See README.md - 'Authenticating' for details\n")
                 self.help_message_displayed = True
 

--- a/seerpy/auth.py
+++ b/seerpy/auth.py
@@ -10,6 +10,10 @@ DEFAULT_COOKIE_KEY = 'seer.sid'
 
 
 class BaseAuth:
+    """
+    An authenticated connection to the Seer API. Should not be used directly,
+    instead use one of the deriving classes.
+    """
     def __init__(self, api_url):
         self.api_url = api_url
 
@@ -35,23 +39,16 @@ class BaseAuth:
 
 class SeerAuth(BaseAuth):
     """
-    Creates a default connection factory, which should be used
-    for most API use cases.
+    Creates an authenticated connection to the Seer API. This is the default for most use cases.
     """
 
     help_message_displayed = False
 
-    def __init__(
-            self,
-            api_url=None,
-            email=None,
-            password=None,
-            cookie_key=DEFAULT_COOKIE_KEY,
-            credential_namespace='cookie'):
+    def __init__(self, api_url=None, email=None, password=None, cookie_key=DEFAULT_COOKIE_KEY,
+                 credential_namespace='cookie'):
 
         super(SeerAuth, self).__init__(
-            api_url if api_url is not None \
-                else f"https://api.seermedical.com/api"
+            api_url if api_url is not None else f"https://api.seermedical.com/api"
         )
 
         self.cookie = None
@@ -153,8 +150,7 @@ class SeerAuth(BaseAuth):
             self.email = input('Email Address: ')
             self.password = getpass.getpass('Password: ')
             if not self.help_message_displayed:
-                print(
-                    f"\nHint: To skip this in future, save your details to {pswdfile}")
+                print(f"\nHint: To skip this in future, save your details to {pswdfile}")
                 print("See README.md - 'Authenticating' for details\n")
                 self.help_message_displayed = True
 

--- a/seerpy/auth.py
+++ b/seerpy/auth.py
@@ -54,11 +54,11 @@ class SeerAuth(BaseAuth):
         self.cookie = None
         self.cookie_key = cookie_key
         self.credential_namespace = credential_namespace
-        self.__read_cookie()
+        self._read_cookie()
 
         self.email = email
         self.password = password
-        self.__attempt_login()
+        self._attempt_login()
 
     def get_connection_parameters(self, party_id=None):
         return super().get_connection_parameters(party_id=party_id)
@@ -86,13 +86,13 @@ class SeerAuth(BaseAuth):
 
     def logout(self):
         home = os.path.expanduser('~')
-        cookie_file = home + self.__get_cookie_path()
+        cookie_file = home + self._get_cookie_path()
         if os.path.isfile(cookie_file):
             os.remove(cookie_file)
         self.cookie = None
 
-    def __attempt_login(self):
-        if self.__verify_login() == 200:
+    def _attempt_login(self):
+        if self._verify_login() == 200:
             print('Login Successful')
             return
 
@@ -100,9 +100,9 @@ class SeerAuth(BaseAuth):
 
         for i in range(allowed_attempts):
             if not self.email or not self.password:
-                self.__login_details()
+                self._login_details()
             self.login()
-            response = self.__verify_login()
+            response = self._verify_login()
 
             if response == requests.codes.ok:  # pylint: disable=maybe-no-member
                 print('Login Successful')
@@ -119,7 +119,7 @@ class SeerAuth(BaseAuth):
                 self.password = None
                 raise InterruptedError('Authentication Failed')
 
-    def __verify_login(self):
+    def _verify_login(self):
         if self.cookie is None:
             return 401
 
@@ -135,10 +135,10 @@ class SeerAuth(BaseAuth):
             print("api verify call did not return an active session")
             return 401
 
-        self.__write_cookie()
+        self._write_cookie()
         return response.status_code
 
-    def __login_details(self):
+    def _login_details(self):
         home = os.path.expanduser('~')
         pswdfile = home + '/.seerpy/credentials'
         if os.path.isfile(pswdfile):
@@ -154,13 +154,13 @@ class SeerAuth(BaseAuth):
                 print("See README.md - 'Authenticating' for details\n")
                 self.help_message_displayed = True
 
-    def __get_cookie_path(self):
+    def _get_cookie_path(self):
         return f'/.seerpy/${self.credential_namespace}'
 
-    def __write_cookie(self):
+    def _write_cookie(self):
         try:
             home = os.path.expanduser('~')
-            cookie_file = home + self.__get_cookie_path()
+            cookie_file = home + self._get_cookie_path()
             if not os.path.isdir(home + '/.seerpy'):
                 os.mkdir(home + '/.seerpy')
             with open(cookie_file, 'w') as f:
@@ -168,9 +168,9 @@ class SeerAuth(BaseAuth):
         except Exception:  # pylint:disable=broad-except
             pass
 
-    def __read_cookie(self):
+    def _read_cookie(self):
         home = os.path.expanduser('~')
-        cookie_file = home + self.__get_cookie_path()
+        cookie_file = home + self._get_cookie_path()
         if os.path.isfile(cookie_file):
             with open(cookie_file, 'r') as f:
                 self.cookie = json.loads(f.read().strip())

--- a/seerpy/auth.py
+++ b/seerpy/auth.py
@@ -48,7 +48,7 @@ class SeerAuth(BaseAuth):
                  credential_namespace='cookie'):
 
         super(SeerAuth, self).__init__(
-            api_url if api_url is not None else f"https://api.seermedical.com/api"
+            api_url if api_url is not None else "https://api.seermedical.com/api"
         )
 
         self.cookie = None

--- a/seerpy/seerpy.py
+++ b/seerpy/seerpy.py
@@ -52,8 +52,6 @@ class SeerConnect:  # pylint: disable=too-many-public-methods
     def create_client(self):
         def graphql_client(party_id=None):
             connection_params = self.seer_auth.get_connection_parameters(party_id)
-            print(connection_params)
-
             return GQLClient(
                 transport=RequestsHTTPTransport(**connection_params)
             )
@@ -525,7 +523,7 @@ class SeerConnect:  # pylint: disable=too-many-public-methods
         if not patient:
             return pd.DataFrame({})
         return json_normalize(patient).sort_index(axis=1)
-        
+
     def get_patients(self, party_id=None):
         query_string = graphql.get_patients_query_string()
         response = self.execute_query(query_string, party_id)['patients']

--- a/seerpy/seerpy.py
+++ b/seerpy/seerpy.py
@@ -1,5 +1,6 @@
 # Copyright 2017 Seer Medical Pty Ltd, Inc. or its affiliates. All Rights Reserved.
 
+from datetime import datetime
 import math
 import time
 import json
@@ -9,16 +10,16 @@ from gql.transport.requests import RequestsHTTPTransport
 import pandas as pd
 from pandas.io.json import json_normalize
 import requests
-from datetime import datetime
 
-from .auth import SeerAuth, COOKIE_KEY_DEV, COOKIE_KEY_PROD
+from . import auth
 from . import utils
 from . import graphql
 
 
 class SeerConnect:  # pylint: disable=too-many-public-methods
+    graphql_client = None
 
-    def __init__(self, api_url='https://api.seermedical.com/api', email=None, password=None, dev=False):
+    def __init__(self, api_url='https://api.seermedical.com/api', email=None, password=None, auth=None):
         """Creates a GraphQL client able to interact with
             the Seer database, handling login and authorisation
         Parameters
@@ -36,33 +37,22 @@ class SeerConnect:  # pylint: disable=too-many-public-methods
 
         """
 
-        self.api_url = api_url
-        self.dev = dev
+        if auth is None:
+            self.seer_auth = auth.SeerDefaultAuth(api_url, email, password)
+        else:
+            self.seer_auth = auth
 
-        self.login(email, password)
+        self.seer_auth.login()
 
         self.last_query_time = time.time()
         self.api_limit_expire = 300
         self.api_limit = 580
 
-    def login(self, email=None, password=None):
-        self.seer_auth = SeerAuth(self.api_url, email, password, self.dev)
-        cookie = self.seer_auth.cookie
-
-        key = COOKIE_KEY_DEV if self.dev else COOKIE_KEY_PROD
-        header =  {
-            'Cookie': f'{key}={cookie[key]}'
-        }
-
+    def login(self):
         def graphql_client(party_id=None):
-            url_suffix = '?partyId=' + party_id if party_id else ''
-            url = self.api_url + '/graphql' + url_suffix
             return GQLClient(
                 transport=RequestsHTTPTransport(
-                    url=url,
-                    headers=header,
-                    use_json=True,
-                    timeout=30
+                    **self.seer_auth.get_connection(party_id)
                 )
             )
 
@@ -86,7 +76,7 @@ class SeerConnect:  # pylint: disable=too-many-public-methods
             error_string = str(ex)
             if any(api_error in error_string for api_error in resolvable_api_errors):
                 if 'NOT_AUTHENTICATED' in error_string:
-                    self.seer_auth.destroy_cookie()
+                    self.seer_auth.logout()
                 else:
                     print('"', error_string, '" raised, trying again after a short break')
                     time.sleep(min(30 * (invocations+1)**2,

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -4,7 +4,7 @@ from unittest import mock
 
 import pytest
 
-from seerpy.auth import SeerAuth, DEFAULT_COOKIE_KEY
+from seerpy.auth import BaseAuth, SeerAuth, DEFAULT_COOKIE_KEY
 
 
 # having a class is useful to allow patches to be shared across mutliple test functions, but then
@@ -54,3 +54,21 @@ class TestAuth:
 
         with pytest.raises(InterruptedError):
             SeerAuth("api-url")
+
+
+class TestBaseAuth:
+    def test_get_connection_parameters_with_party_id(self):
+        auth = BaseAuth('abcd')
+        params = auth.get_connection_parameters('1234')
+        assert params['url'] == 'abcd/graphql?partyId=1234'
+
+    def test_correct_parameters_are_returned(self):
+        auth = BaseAuth('abcd')
+        params = auth.get_connection_parameters()
+
+        assert params == {
+            'url': 'abcd/graphql',
+            'headers': {},
+            'use_json': True,
+            'timeout': 30
+        }

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -23,7 +23,7 @@ class TestAuth:
     # if there is an existing cookie then readCookie will interfere with the test
     @mock.patch.object(
         SeerAuth,
-        "_SeerAuth__read_cookie",
+        "_read_cookie",
         autospec=True
     )
     def test_success(self, read_cookie, requests_post,  # pylint:disable=unused-argument

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -4,7 +4,7 @@ from unittest import mock
 
 import pytest
 
-from seerpy.auth import DefaultConnectionFactory, DEFAULT_COOKIE_KEY
+from seerpy.auth import SeerAuth, DEFAULT_COOKIE_KEY
 
 
 # having a class is useful to allow patches to be shared across mutliple test functions, but then
@@ -21,7 +21,11 @@ from seerpy.auth import DefaultConnectionFactory, DEFAULT_COOKIE_KEY
 class TestAuth:
 
     # if there is an existing cookie then readCookie will interfere with the test
-    @mock.patch.object(DefaultConnectionFactory, "read_cookie", autospec=True)
+    @mock.patch.object(
+        SeerAuth,
+        "_SeerAuth__read_cookie",
+        autospec=True
+    )
     def test_success(self, read_cookie, requests_post,  # pylint:disable=unused-argument
                      requests_get, email_input, password_getpass):  # pylint:disable=unused-argument
         requests_post.return_value.status_code = 200
@@ -29,7 +33,7 @@ class TestAuth:
         requests_get.return_value.status_code = 200
         requests_get.return_value.json.return_value = {"session": "active"}
 
-        result = DefaultConnectionFactory("api-url")
+        result = SeerAuth("api-url")
 
         assert result.cookie[DEFAULT_COOKIE_KEY] == "cookie"
 
@@ -40,7 +44,7 @@ class TestAuth:
         requests_get.return_value.status_code = 401
 
         with pytest.raises(InterruptedError):
-            DefaultConnectionFactory("api-url")
+            SeerAuth("api-url")
 
     def test_other_error(self, requests_post, requests_get,
                          email_input, password_getpass):  # pylint:disable=unused-argument
@@ -49,4 +53,4 @@ class TestAuth:
         requests_get.return_value.status_code = "undefined"
 
         with pytest.raises(InterruptedError):
-            DefaultConnectionFactory("api-url")
+            SeerAuth("api-url")

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -4,7 +4,7 @@ from unittest import mock
 
 import pytest
 
-from seerpy.auth import SeerAuth, COOKIE_KEY_PROD
+from seerpy.auth import DefaultConnectionFactory, DEFAULT_COOKIE_KEY
 
 
 # having a class is useful to allow patches to be shared across mutliple test functions, but then
@@ -21,32 +21,32 @@ from seerpy.auth import SeerAuth, COOKIE_KEY_PROD
 class TestAuth:
 
     # if there is an existing cookie then readCookie will interfere with the test
-    @mock.patch.object(SeerAuth, "read_cookie", autospec=True)
+    @mock.patch.object(DefaultConnectionFactory, "read_cookie", autospec=True)
     def test_success(self, read_cookie, requests_post,  # pylint:disable=unused-argument
                      requests_get, email_input, password_getpass):  # pylint:disable=unused-argument
         requests_post.return_value.status_code = 200
-        requests_post.return_value.cookies = {COOKIE_KEY_PROD: "cookie"}
+        requests_post.return_value.cookies = {DEFAULT_COOKIE_KEY: "cookie"}
         requests_get.return_value.status_code = 200
         requests_get.return_value.json.return_value = {"session": "active"}
 
-        result = SeerAuth("api-url")
+        result = DefaultConnectionFactory("api-url")
 
-        assert result.cookie[COOKIE_KEY_PROD] == "cookie"
+        assert result.cookie[DEFAULT_COOKIE_KEY] == "cookie"
 
     def test_401_error(self, requests_post, requests_get,
                        email_input, password_getpass):  # pylint:disable=unused-argument
         requests_post.return_value.status_code = 200
-        requests_post.return_value.cookies = {COOKIE_KEY_PROD: "cookie"}
+        requests_post.return_value.cookies = {DEFAULT_COOKIE_KEY: "cookie"}
         requests_get.return_value.status_code = 401
 
         with pytest.raises(InterruptedError):
-            SeerAuth("api-url")
+            DefaultConnectionFactory("api-url")
 
     def test_other_error(self, requests_post, requests_get,
                          email_input, password_getpass):  # pylint:disable=unused-argument
         requests_post.return_value.status_code = 200
-        requests_post.return_value.cookies = {COOKIE_KEY_PROD: "cookie"}
+        requests_post.return_value.cookies = {DEFAULT_COOKIE_KEY: "cookie"}
         requests_get.return_value.status_code = "undefined"
 
         with pytest.raises(InterruptedError):
-            SeerAuth("api-url")
+            DefaultConnectionFactory("api-url")

--- a/tests/test_seerpy.py
+++ b/tests/test_seerpy.py
@@ -23,6 +23,9 @@ from seerpy.auth import DEFAULT_COOKIE_KEY
 TEST_DATA_DIR = pathlib.Path(__file__).parent / "test_data"
 
 
+DEFAULT_CONNECTION_PARAMS = {'url': '.'}
+
+
 @mock.patch('seerpy.seerpy.SeerAuth', autospec=True)
 class TestSeerConnect:
 
@@ -32,13 +35,6 @@ class TestSeerConnect:
         result = SeerConnect()
 
         assert result.graphql_client
-
-    def test_login_unauthorized(self, seer_auth):
-        seer_auth.return_value.cookie = None
-
-        # not really desired behaviour, just documenting current behaviour
-        with pytest.raises(TypeError):
-            SeerConnect()
 
     def test_login_error(self, seer_auth):
         seer_auth.side_effect = InterruptedError('Authentication Failed')
@@ -94,6 +90,7 @@ class TestGetAllStudyMetaDataByNames:
     def test_no_study_param(self, seer_auth, gql_client, unused_time_sleep):
         # setup
         seer_auth.return_value.cookie = {DEFAULT_COOKIE_KEY: "cookie"}
+        seer_auth.return_value.get_connection_parameters.return_value = DEFAULT_CONNECTION_PARAMS
 
         side_effects = []
 
@@ -113,6 +110,7 @@ class TestGetAllStudyMetaDataByNames:
                 expected_results.append(study['study'])
 
         gql_client.return_value.execute.side_effect = side_effects
+        seer_auth.get_connection_parameters.return_value = DEFAULT_CONNECTION_PARAMS
 
         # run test
         result = SeerConnect().get_all_study_metadata_by_names()
@@ -123,6 +121,7 @@ class TestGetAllStudyMetaDataByNames:
     def test_existing_study_param(self, seer_auth, gql_client, unused_time_sleep):
         # setup
         seer_auth.return_value.cookie = {DEFAULT_COOKIE_KEY: "cookie"}
+        seer_auth.return_value.get_connection_parameters.return_value = DEFAULT_CONNECTION_PARAMS
 
         side_effects = []
 
@@ -150,6 +149,7 @@ class TestGetAllStudyMetaDataByNames:
     def test_getting_multiple_study_ids_by_name(self, seer_auth, gql_client, unused_time_sleep):
         # setup
         seer_auth.return_value.cookie = {DEFAULT_COOKIE_KEY: "cookie"}
+        seer_auth.return_value.get_connection_parameters.return_value = DEFAULT_CONNECTION_PARAMS
 
         side_effects = []
 
@@ -183,6 +183,7 @@ class TestGetAllStudyMetaDataByNames:
     def test_nonexistent_study_param(self, seer_auth, gql_client, unused_time_sleep):
         # setup
         seer_auth.return_value.cookie = {DEFAULT_COOKIE_KEY: "cookie"}
+        seer_auth.return_value.get_connection_parameters.return_value = DEFAULT_CONNECTION_PARAMS
 
         side_effects = []
 
@@ -208,6 +209,7 @@ class TestGetSegmentUrls:
     def test_success(self, seer_auth, gql_client, unused_time_sleep):
         # setup
         seer_auth.return_value.cookie = {DEFAULT_COOKIE_KEY: "cookie"}
+        seer_auth.return_value.get_connection_parameters.return_value = DEFAULT_CONNECTION_PARAMS
 
         with open(TEST_DATA_DIR / "segment_urls_1.json", "r") as f:
             gql_client.return_value.execute.return_value = json.load(f)
@@ -223,6 +225,7 @@ class TestGetSegmentUrls:
     def test_multiple_batches(self, seer_auth, gql_client, unused_time_sleep):
         # setup
         seer_auth.return_value.cookie = {DEFAULT_COOKIE_KEY: "cookie"}
+        seer_auth.return_value.get_connection_parameters.return_value = DEFAULT_CONNECTION_PARAMS
 
         side_effects = []
         for file_name in ["segment_urls_1.json", "segment_urls_2.json"]:
@@ -266,6 +269,7 @@ class TestGetSegmentUrls:
     def test_unmatched_segment_ids(self, seer_auth, gql_client, unused_time_sleep):
         # setup
         seer_auth.return_value.cookie = {DEFAULT_COOKIE_KEY: "cookie"}
+        seer_auth.return_value.get_connection_parameters.return_value = DEFAULT_CONNECTION_PARAMS
 
         with open(TEST_DATA_DIR / "segment_urls_no_match.json", "r") as f:
             gql_client.return_value.execute.return_value = json.load(f)
@@ -285,6 +289,7 @@ class TestGetLabels:
     def test_success(self, seer_auth, gql_client, unused_time_sleep):
         # setup
         seer_auth.return_value.cookie = {DEFAULT_COOKIE_KEY: "cookie"}
+        seer_auth.return_value.get_connection_parameters.return_value = DEFAULT_CONNECTION_PARAMS
 
         side_effects = []
 
@@ -316,6 +321,7 @@ class TestGetLabelsDataframe:
     def test_success(self, seer_auth, gql_client, unused_time_sleep):
         # setup
         seer_auth.return_value.cookie = {DEFAULT_COOKIE_KEY: "cookie"}
+        seer_auth.return_value.get_connection_parameters.return_value = DEFAULT_CONNECTION_PARAMS
 
         side_effects = []
 
@@ -346,6 +352,7 @@ class TestGetViewedTimesDataframe:
     def test_success(self, seer_auth, gql_client, unused_time_sleep):
         # setup
         seer_auth.return_value.cookie = {DEFAULT_COOKIE_KEY: "cookie"}
+        seer_auth.return_value.get_connection_parameters.return_value = DEFAULT_CONNECTION_PARAMS
 
         side_effects = []
 
@@ -377,6 +384,7 @@ class TestGetDocumentsForStudiesDataframe:
     def test_success(self, seer_auth, gql_client, unused_time_sleep):
         # setup
         seer_auth.return_value.cookie = {DEFAULT_COOKIE_KEY: "cookie"}
+        seer_auth.return_value.get_connection_parameters.return_value = DEFAULT_CONNECTION_PARAMS
 
         side_effects = []
 
@@ -407,6 +415,7 @@ class TestGetDocumentsForStudiesDataframe:
 class TestGetMoodSurveyResults:
     def test_get_results(self, seer_auth, gql_client):
         seer_auth.return_value.cookie = {DEFAULT_COOKIE_KEY: "cookie"}
+        seer_auth.return_value.get_connection_parameters.return_value = DEFAULT_CONNECTION_PARAMS
 
         side_effects = []
         with open(TEST_DATA_DIR / "mood_survey_response_1.json", "r") as f:
@@ -423,6 +432,7 @@ class TestGetMoodSurveyResults:
 
     def test_get_results_dataframe(self, seer_auth, gql_client):
         seer_auth.return_value.cookie = {DEFAULT_COOKIE_KEY: "cookie"}
+        seer_auth.return_value.get_connection_parameters.return_value = DEFAULT_CONNECTION_PARAMS
 
         side_effects = []
         with open(TEST_DATA_DIR / "mood_survey_response_1.json", "r") as f:
@@ -438,6 +448,7 @@ class TestGetMoodSurveyResults:
 
     def test_get_multiple_results_pages_dataframe(self, seer_auth, gql_client):
         seer_auth.return_value.cookie = {DEFAULT_COOKIE_KEY: "cookie"}
+        seer_auth.return_value.get_connection_parameters.return_value = DEFAULT_CONNECTION_PARAMS
 
         side_effects = []
         with open(TEST_DATA_DIR / "mood_survey_response_1.json", "r") as f:
@@ -455,6 +466,7 @@ class TestGetMoodSurveyResults:
 
     def test_get_empty_results_dataframe(self, seer_auth, gql_client):
         seer_auth.return_value.cookie = {DEFAULT_COOKIE_KEY: "cookie"}
+        seer_auth.return_value.get_connection_parameters.return_value = DEFAULT_CONNECTION_PARAMS
 
         side_effects = []
         with open(TEST_DATA_DIR / "mood_survey_response_empty.json", "r") as f:
@@ -471,6 +483,7 @@ class TestStudyCohorts:
     def test_get_study_ids_in_study_cohort(self, seer_auth, gql_client):
         # setup
         seer_auth.return_value.cookie = {DEFAULT_COOKIE_KEY: "cookie"}
+        seer_auth.return_value.get_connection_parameters.return_value = DEFAULT_CONNECTION_PARAMS
 
         side_effects = []
 
@@ -545,6 +558,7 @@ class TestUserCohorts:
     def test_get_user_ids_in_user_cohort(self, seer_auth, gql_client):
         # setup
         seer_auth.return_value.cookie = {'seer.sid': "cookie"}
+        seer_auth.return_value.get_connection_parameters.return_value = DEFAULT_CONNECTION_PARAMS
 
         side_effects = []
 
@@ -577,6 +591,7 @@ class TestUserCohorts:
     def test_get_user_ids_in_user_cohort_with_no_users(self, seer_auth, gql_client):
         # setup
         seer_auth.return_value.cookie = {'seer.sid': "cookie"}
+        seer_auth.return_value.get_connection_parameters.return_value = DEFAULT_CONNECTION_PARAMS
 
         side_effects = []
 

--- a/tests/test_seerpy.py
+++ b/tests/test_seerpy.py
@@ -9,7 +9,7 @@ import pandas as pd
 
 from seerpy.seerpy import SeerConnect
 import seerpy.graphql as graphql
-from seerpy.auth import COOKIE_KEY_PROD
+from seerpy.auth import DEFAULT_COOKIE_KEY
 
 
 # having a class is useful to allow patches to be shared across mutliple test functions, but then
@@ -27,7 +27,7 @@ TEST_DATA_DIR = pathlib.Path(__file__).parent / "test_data"
 class TestSeerConnect:
 
     def test_success(self, seer_auth):
-        seer_auth.return_value.cookie = {COOKIE_KEY_PROD: "cookie"}
+        seer_auth.return_value.cookie = {DEFAULT_COOKIE_KEY: "cookie"}
 
         result = SeerConnect()
 
@@ -93,7 +93,7 @@ class TestGetAllStudyMetaDataByNames:
 
     def test_no_study_param(self, seer_auth, gql_client, unused_time_sleep):
         # setup
-        seer_auth.return_value.cookie = {COOKIE_KEY_PROD: "cookie"}
+        seer_auth.return_value.cookie = {DEFAULT_COOKIE_KEY: "cookie"}
 
         side_effects = []
 
@@ -122,7 +122,7 @@ class TestGetAllStudyMetaDataByNames:
 
     def test_existing_study_param(self, seer_auth, gql_client, unused_time_sleep):
         # setup
-        seer_auth.return_value.cookie = {COOKIE_KEY_PROD: "cookie"}
+        seer_auth.return_value.cookie = {DEFAULT_COOKIE_KEY: "cookie"}
 
         side_effects = []
 
@@ -149,7 +149,7 @@ class TestGetAllStudyMetaDataByNames:
 
     def test_getting_multiple_study_ids_by_name(self, seer_auth, gql_client, unused_time_sleep):
         # setup
-        seer_auth.return_value.cookie = {COOKIE_KEY_PROD: "cookie"}
+        seer_auth.return_value.cookie = {DEFAULT_COOKIE_KEY: "cookie"}
 
         side_effects = []
 
@@ -182,7 +182,7 @@ class TestGetAllStudyMetaDataByNames:
 
     def test_nonexistent_study_param(self, seer_auth, gql_client, unused_time_sleep):
         # setup
-        seer_auth.return_value.cookie = {COOKIE_KEY_PROD: "cookie"}
+        seer_auth.return_value.cookie = {DEFAULT_COOKIE_KEY: "cookie"}
 
         side_effects = []
 
@@ -207,7 +207,7 @@ class TestGetSegmentUrls:
 
     def test_success(self, seer_auth, gql_client, unused_time_sleep):
         # setup
-        seer_auth.return_value.cookie = {COOKIE_KEY_PROD: "cookie"}
+        seer_auth.return_value.cookie = {DEFAULT_COOKIE_KEY: "cookie"}
 
         with open(TEST_DATA_DIR / "segment_urls_1.json", "r") as f:
             gql_client.return_value.execute.return_value = json.load(f)
@@ -222,7 +222,7 @@ class TestGetSegmentUrls:
 
     def test_multiple_batches(self, seer_auth, gql_client, unused_time_sleep):
         # setup
-        seer_auth.return_value.cookie = {COOKIE_KEY_PROD: "cookie"}
+        seer_auth.return_value.cookie = {DEFAULT_COOKIE_KEY: "cookie"}
 
         side_effects = []
         for file_name in ["segment_urls_1.json", "segment_urls_2.json"]:
@@ -241,7 +241,7 @@ class TestGetSegmentUrls:
 
     def test_none_segment_ids(self, seer_auth, unused_gql_client, unused_time_sleep):
         # setup
-        seer_auth.return_value.cookie = {COOKIE_KEY_PROD: "cookie"}
+        seer_auth.return_value.cookie = {DEFAULT_COOKIE_KEY: "cookie"}
 
         expected_result = pd.read_csv(TEST_DATA_DIR / "segment_urls_empty.csv", index_col=0)
 
@@ -253,7 +253,7 @@ class TestGetSegmentUrls:
 
     def test_empty_segment_ids(self, seer_auth, unused_gql_client, unused_time_sleep):
         # setup
-        seer_auth.return_value.cookie = {COOKIE_KEY_PROD: "cookie"}
+        seer_auth.return_value.cookie = {DEFAULT_COOKIE_KEY: "cookie"}
 
         # gql_client is never called as we don't enter the loop
 
@@ -265,7 +265,7 @@ class TestGetSegmentUrls:
 
     def test_unmatched_segment_ids(self, seer_auth, gql_client, unused_time_sleep):
         # setup
-        seer_auth.return_value.cookie = {COOKIE_KEY_PROD: "cookie"}
+        seer_auth.return_value.cookie = {DEFAULT_COOKIE_KEY: "cookie"}
 
         with open(TEST_DATA_DIR / "segment_urls_no_match.json", "r") as f:
             gql_client.return_value.execute.return_value = json.load(f)
@@ -284,7 +284,7 @@ class TestGetLabels:
 
     def test_success(self, seer_auth, gql_client, unused_time_sleep):
         # setup
-        seer_auth.return_value.cookie = {COOKIE_KEY_PROD: "cookie"}
+        seer_auth.return_value.cookie = {DEFAULT_COOKIE_KEY: "cookie"}
 
         side_effects = []
 
@@ -315,7 +315,7 @@ class TestGetLabelsDataframe:
 
     def test_success(self, seer_auth, gql_client, unused_time_sleep):
         # setup
-        seer_auth.return_value.cookie = {COOKIE_KEY_PROD: "cookie"}
+        seer_auth.return_value.cookie = {DEFAULT_COOKIE_KEY: "cookie"}
 
         side_effects = []
 
@@ -345,7 +345,7 @@ class TestGetViewedTimesDataframe:
 
     def test_success(self, seer_auth, gql_client, unused_time_sleep):
         # setup
-        seer_auth.return_value.cookie = {COOKIE_KEY_PROD: "cookie"}
+        seer_auth.return_value.cookie = {DEFAULT_COOKIE_KEY: "cookie"}
 
         side_effects = []
 
@@ -376,7 +376,7 @@ class TestGetDocumentsForStudiesDataframe:
 
     def test_success(self, seer_auth, gql_client, unused_time_sleep):
         # setup
-        seer_auth.return_value.cookie = {COOKIE_KEY_PROD: "cookie"}
+        seer_auth.return_value.cookie = {DEFAULT_COOKIE_KEY: "cookie"}
 
         side_effects = []
 
@@ -406,7 +406,7 @@ class TestGetDocumentsForStudiesDataframe:
 @mock.patch('seerpy.seerpy.SeerAuth', autospec=True)
 class TestGetMoodSurveyResults:
     def test_get_results(self, seer_auth, gql_client):
-        seer_auth.return_value.cookie = {COOKIE_KEY_PROD: "cookie"}
+        seer_auth.return_value.cookie = {DEFAULT_COOKIE_KEY: "cookie"}
 
         side_effects = []
         with open(TEST_DATA_DIR / "mood_survey_response_1.json", "r") as f:
@@ -422,7 +422,7 @@ class TestGetMoodSurveyResults:
         assert result == expected_result
 
     def test_get_results_dataframe(self, seer_auth, gql_client):
-        seer_auth.return_value.cookie = {COOKIE_KEY_PROD: "cookie"}
+        seer_auth.return_value.cookie = {DEFAULT_COOKIE_KEY: "cookie"}
 
         side_effects = []
         with open(TEST_DATA_DIR / "mood_survey_response_1.json", "r") as f:
@@ -437,7 +437,7 @@ class TestGetMoodSurveyResults:
         pd.testing.assert_frame_equal(result, expected_result)
 
     def test_get_multiple_results_pages_dataframe(self, seer_auth, gql_client):
-        seer_auth.return_value.cookie = {COOKIE_KEY_PROD: "cookie"}
+        seer_auth.return_value.cookie = {DEFAULT_COOKIE_KEY: "cookie"}
 
         side_effects = []
         with open(TEST_DATA_DIR / "mood_survey_response_1.json", "r") as f:
@@ -454,7 +454,7 @@ class TestGetMoodSurveyResults:
         pd.testing.assert_frame_equal(result, expected_result)
 
     def test_get_empty_results_dataframe(self, seer_auth, gql_client):
-        seer_auth.return_value.cookie = {COOKIE_KEY_PROD: "cookie"}
+        seer_auth.return_value.cookie = {DEFAULT_COOKIE_KEY: "cookie"}
 
         side_effects = []
         with open(TEST_DATA_DIR / "mood_survey_response_empty.json", "r") as f:
@@ -470,7 +470,7 @@ class TestGetMoodSurveyResults:
 class TestStudyCohorts:
     def test_get_study_ids_in_study_cohort(self, seer_auth, gql_client):
         # setup
-        seer_auth.return_value.cookie = {COOKIE_KEY_PROD: "cookie"}
+        seer_auth.return_value.cookie = {DEFAULT_COOKIE_KEY: "cookie"}
 
         side_effects = []
 


### PR DESCRIPTION
This provides greater flexibility in logging in using different approaches. Currently only "Base" (no auth) "Default" and "Dev" modes are supported. Existing behaviour is maintained by defaulting to `SeerAuth` where no auth strategy is provided.

- [x] fix mock.patches on tests
- [x] fix / add any required tests
- [x] document