### PR TITLE
Mock time.sleep in tests using execute_query to speed them up.

### DIFF
--- a/tests/test_seerpy.py
+++ b/tests/test_seerpy.py
@@ -91,7 +91,7 @@ class TestGetAllStudyMetaDataDataframeByIds:
 @mock.patch('seerpy.seerpy.SeerAuth', autospec=True)
 class TestGetAllStudyMetaDataByNames:
 
-    def test_no_study_param(self, seer_auth, gql_client, unused_time_sleep):
+    def test_no_study_param(self, seer_auth, gql_client, unused_sleep):
         # setup
         seer_auth.return_value.cookie = {COOKIE_KEY_PROD: "cookie"}
 
@@ -120,7 +120,7 @@ class TestGetAllStudyMetaDataByNames:
         # check result
         assert result == {'studies' : expected_results}
 
-    def test_existing_study_param(self, seer_auth, gql_client, unused_time_sleep):
+    def test_existing_study_param(self, seer_auth, gql_client, unused_sleep):
         # setup
         seer_auth.return_value.cookie = {COOKIE_KEY_PROD: "cookie"}
 
@@ -147,7 +147,7 @@ class TestGetAllStudyMetaDataByNames:
         # check result
         assert result == {'studies' : expected_results}
 
-    def test_getting_multiple_study_ids_by_name(self, seer_auth, gql_client, unused_time_sleep):
+    def test_getting_multiple_study_ids_by_name(self, seer_auth, gql_client, unused_sleep):
         # setup
         seer_auth.return_value.cookie = {COOKIE_KEY_PROD: "cookie"}
 
@@ -180,7 +180,7 @@ class TestGetAllStudyMetaDataByNames:
         # check result
         assert result == expected_results
 
-    def test_nonexistent_study_param(self, seer_auth, gql_client, unused_time_sleep):
+    def test_nonexistent_study_param(self, seer_auth, gql_client, unused_sleep):
         # setup
         seer_auth.return_value.cookie = {COOKIE_KEY_PROD: "cookie"}
 
@@ -205,7 +205,7 @@ class TestGetAllStudyMetaDataByNames:
 @mock.patch('seerpy.seerpy.SeerAuth', autospec=True)
 class TestGetSegmentUrls:
 
-    def test_success(self, seer_auth, gql_client, unused_time_sleep):
+    def test_success(self, seer_auth, gql_client, unused_sleep):
         # setup
         seer_auth.return_value.cookie = {COOKIE_KEY_PROD: "cookie"}
 
@@ -220,7 +220,7 @@ class TestGetSegmentUrls:
         # check result
         pd.testing.assert_frame_equal(result, expected_result)
 
-    def test_multiple_batches(self, seer_auth, gql_client, unused_time_sleep):
+    def test_multiple_batches(self, seer_auth, gql_client, unused_sleep):
         # setup
         seer_auth.return_value.cookie = {COOKIE_KEY_PROD: "cookie"}
 
@@ -239,7 +239,7 @@ class TestGetSegmentUrls:
         # check result
         pd.testing.assert_frame_equal(result, expected_result)
 
-    def test_none_segment_ids(self, seer_auth, unused_gql_client, unused_time_sleep):
+    def test_none_segment_ids(self, seer_auth, unused_gql_client, unused_sleep):
         # setup
         seer_auth.return_value.cookie = {COOKIE_KEY_PROD: "cookie"}
 
@@ -251,7 +251,7 @@ class TestGetSegmentUrls:
         # check result
         pd.testing.assert_frame_equal(result, expected_result)
 
-    def test_empty_segment_ids(self, seer_auth, unused_gql_client, unused_time_sleep):
+    def test_empty_segment_ids(self, seer_auth, unused_gql_client, unused_sleep):
         # setup
         seer_auth.return_value.cookie = {COOKIE_KEY_PROD: "cookie"}
 
@@ -263,7 +263,7 @@ class TestGetSegmentUrls:
         # check result
         assert result.empty
 
-    def test_unmatched_segment_ids(self, seer_auth, gql_client, unused_time_sleep):
+    def test_unmatched_segment_ids(self, seer_auth, gql_client, unused_sleep):
         # setup
         seer_auth.return_value.cookie = {COOKIE_KEY_PROD: "cookie"}
 
@@ -282,7 +282,7 @@ class TestGetSegmentUrls:
 @mock.patch('seerpy.seerpy.SeerAuth', autospec=True)
 class TestGetLabels:
 
-    def test_success(self, seer_auth, gql_client, unused_time_sleep):
+    def test_success(self, seer_auth, gql_client, unused_sleep):
         # setup
         seer_auth.return_value.cookie = {COOKIE_KEY_PROD: "cookie"}
 
@@ -313,7 +313,7 @@ class TestGetLabels:
 @mock.patch('seerpy.seerpy.SeerAuth', autospec=True)
 class TestGetLabelsDataframe:
 
-    def test_success(self, seer_auth, gql_client, unused_time_sleep):
+    def test_success(self, seer_auth, gql_client, unused_sleep):
         # setup
         seer_auth.return_value.cookie = {COOKIE_KEY_PROD: "cookie"}
 
@@ -343,7 +343,7 @@ class TestGetLabelsDataframe:
 @mock.patch('seerpy.seerpy.SeerAuth', autospec=True)
 class TestGetViewedTimesDataframe:
 
-    def test_success(self, seer_auth, gql_client, unused_time_sleep):
+    def test_success(self, seer_auth, gql_client, unused_sleep):
         # setup
         seer_auth.return_value.cookie = {COOKIE_KEY_PROD: "cookie"}
 
@@ -374,7 +374,7 @@ class TestGetViewedTimesDataframe:
 @mock.patch('seerpy.seerpy.SeerAuth', autospec=True)
 class TestGetDocumentsForStudiesDataframe:
 
-    def test_success(self, seer_auth, gql_client, unused_time_sleep):
+    def test_success(self, seer_auth, gql_client, unused_sleep):
         # setup
         seer_auth.return_value.cookie = {COOKIE_KEY_PROD: "cookie"}
 
@@ -402,10 +402,11 @@ class TestGetDocumentsForStudiesDataframe:
         pd.testing.assert_frame_equal(result, expected_result, check_like=True)
 
 
+@mock.patch('time.sleep', return_value=None)
 @mock.patch('seerpy.seerpy.GQLClient', autospec=True)
 @mock.patch('seerpy.seerpy.SeerAuth', autospec=True)
 class TestGetMoodSurveyResults:
-    def test_get_results(self, seer_auth, gql_client):
+    def test_get_results(self, seer_auth, gql_client, unused_sleep):
         seer_auth.return_value.cookie = {COOKIE_KEY_PROD: "cookie"}
 
         side_effects = []
@@ -421,7 +422,7 @@ class TestGetMoodSurveyResults:
         result = SeerConnect().get_mood_survey_results(["aMoodSurveyId"])
         assert result == expected_result
 
-    def test_get_results_dataframe(self, seer_auth, gql_client):
+    def test_get_results_dataframe(self, seer_auth, gql_client, unused_sleep):
         seer_auth.return_value.cookie = {COOKIE_KEY_PROD: "cookie"}
 
         side_effects = []
@@ -436,7 +437,7 @@ class TestGetMoodSurveyResults:
         result = SeerConnect().get_mood_survey_results_dataframe(["aMoodSurveyId"])
         pd.testing.assert_frame_equal(result, expected_result)
 
-    def test_get_multiple_results_pages_dataframe(self, seer_auth, gql_client):
+    def test_get_multiple_results_pages_dataframe(self, seer_auth, gql_client, unused_sleep):
         seer_auth.return_value.cookie = {COOKIE_KEY_PROD: "cookie"}
 
         side_effects = []
@@ -453,7 +454,7 @@ class TestGetMoodSurveyResults:
         result = SeerConnect().get_mood_survey_results_dataframe(["aMoodSurveyId"])
         pd.testing.assert_frame_equal(result, expected_result)
 
-    def test_get_empty_results_dataframe(self, seer_auth, gql_client):
+    def test_get_empty_results_dataframe(self, seer_auth, gql_client, unused_sleep):
         seer_auth.return_value.cookie = {COOKIE_KEY_PROD: "cookie"}
 
         side_effects = []
@@ -465,10 +466,11 @@ class TestGetMoodSurveyResults:
         assert result.empty
 
 
-@mock.patch('seerpy.seerpy.GQLClient', autospec=True)
-@mock.patch('seerpy.seerpy.SeerAuth', autospec=True)
 class TestStudyCohorts:
-    def test_get_study_ids_in_study_cohort(self, seer_auth, gql_client):
+    @mock.patch('time.sleep', return_value=None)
+    @mock.patch('seerpy.seerpy.GQLClient', autospec=True)
+    @mock.patch('seerpy.seerpy.SeerAuth', autospec=True)
+    def test_get_study_ids_in_study_cohort(self, seer_auth, gql_client, unused_sleep):
         # setup
         seer_auth.return_value.cookie = {COOKIE_KEY_PROD: "cookie"}
 
@@ -487,7 +489,7 @@ class TestStudyCohorts:
         result = SeerConnect().get_study_ids_in_study_cohort('cohort1')
         assert result == expected_result
 
-    def test_generating_create_mutation(self, unused_seer_auth, unused_gql_client):
+    def test_generating_create_mutation(self):
         query_string = graphql.create_study_cohort_mutation_string(
             'test_cohort', study_ids=['study1', 'study2'])
 
@@ -503,7 +505,7 @@ class TestStudyCohorts:
         }
     """
 
-    def test_generating_add_studies_to_cohort_mutation(self, unused_seer_auth, unused_gql_client):
+    def test_generating_add_studies_to_cohort_mutation(self):
         query_string = graphql.add_studies_to_study_cohort_mutation_string(
             'cohort_id', ['study1', 'study2'])
 
@@ -520,8 +522,7 @@ class TestStudyCohorts:
         }
     """
 
-    def test_generating_remove_studies_from_cohort_mutation(
-            self, unused_seer_auth, unused_gql_client):
+    def test_generating_remove_studies_from_cohort_mutation(self):
         query_string = graphql.remove_studies_from_study_cohort_mutation_string(
             'cohort_id', ['study1', 'study2'])
 
@@ -539,10 +540,11 @@ class TestStudyCohorts:
     """
 
 
+@mock.patch('time.sleep', return_value=None)
 @mock.patch('seerpy.seerpy.GQLClient', autospec=True)
 @mock.patch('seerpy.seerpy.SeerAuth', autospec=True)
 class TestUserCohorts:
-    def test_get_user_ids_in_user_cohort(self, seer_auth, gql_client):
+    def test_get_user_ids_in_user_cohort(self, seer_auth, gql_client, unused_sleep):
         # setup
         seer_auth.return_value.cookie = {'seer.sid': "cookie"}
 
@@ -562,7 +564,8 @@ class TestUserCohorts:
         assert result == expected_result
 
 
-    def test_get_user_ids_in_user_cohort_with_cohort_not_found(self, seer_auth, gql_client):
+    def test_get_user_ids_in_user_cohort_with_cohort_not_found(self, seer_auth, gql_client,
+                                                               unused_sleep):
         # setup
         seer_auth.return_value.cookie = {'seer.sid': "cookie"}
 
@@ -574,7 +577,7 @@ class TestUserCohorts:
             assert str(ex.value) == 'NOT_FOUND'
 
 
-    def test_get_user_ids_in_user_cohort_with_no_users(self, seer_auth, gql_client):
+    def test_get_user_ids_in_user_cohort_with_no_users(self, seer_auth, gql_client, unused_sleep):
         # setup
         seer_auth.return_value.cookie = {'seer.sid': "cookie"}
 
@@ -591,7 +594,8 @@ class TestUserCohorts:
         result = SeerConnect().get_user_ids_in_user_cohort('a-missing-cohort')
         assert result == expected_result
 
-    def test_generating_create_user_cohort_mutation(self, unused_seer_auth, unused_gql_client):
+    def test_generating_create_user_cohort_mutation(self, unused_seer_auth, unused_gql_client,
+                                                    unused_sleep):
         query_string = graphql.get_create_user_cohort_mutation_string(
             'test_cohort', user_ids=['user1', 'user2'])
 
@@ -607,7 +611,8 @@ class TestUserCohorts:
         }
     """
 
-    def test_generating_add_users_to_cohort_mutation(self, unused_seer_auth, unused_gql_client):
+    def test_generating_add_users_to_cohort_mutation(self, unused_seer_auth, unused_gql_client,
+                                                     unused_sleep):
         query_string = graphql.get_add_users_to_user_cohort_mutation_string(
             'cohort_id', ['user1', 'user2'])
 
@@ -624,8 +629,8 @@ class TestUserCohorts:
         }
     """
 
-    def test_generating_remove_users_from_cohort_mutation(
-            self, unused_seer_auth, unused_gql_client):
+    def test_generating_remove_users_from_cohort_mutation(self, unused_seer_auth, unused_gql_client,
+                                                          unused_sleep):
         query_string = graphql.get_remove_users_from_user_cohort_mutation_string(
             'cohort_id', ['user1', 'user2'])
 


### PR DESCRIPTION
Also shortened the parameter name used in existing usage.