### PR TITLE
Make get_paginated_response more flexible

### DIFF
--- a/seerpy/graphql.py
+++ b/seerpy/graphql.py
@@ -123,47 +123,46 @@ def get_study_with_data_query_string(study_id):
         }""" % study_id
 
 
-def get_labels_query_string(study_id, label_group_id,  # pylint:disable=too-many-arguments
-                            from_time, to_time, limit, offset):
-    return """
-        query {
-            study (id: "%s") {
+def get_labels_paged_query_string(study_id, label_group_id, from_time, to_time):
+    return f"""
+        query {{{{
+            study (id: "{study_id}") {{{{
                 id
                 name
-                labelGroup (labelGroupId: "%s") {
+                labelGroup (labelGroupId: "{label_group_id}") {{{{
                     id
                     name
                     labelType
                     description
                     numberOfLabels
-                    labels (limit: %.0f, offset: %.0f, fromTime: %.0f, toTime: %.0f) {
+                    labels (limit: {{limit}}, offset: {{offset}}, fromTime: {from_time}, toTime: {to_time}) {{{{
                         id
                         note
                         startTime
                         duration
                         timezone
                         confidence
-                        createdBy {
+                        createdBy {{{{
                             fullName
-                        }
+                        }}}}
                         updatedAt
                         createdAt
-                        tags {
+                        tags {{{{
                             id
-                            tagType {
+                            tagType {{{{
                                 id
-                                category {
+                                category {{{{
                                     id
                                     name
                                     description
-                                }
+                                }}}}
                                 value
-                            }
-                        }
-                    }
-                }
-            }
-        }""" % (study_id, label_group_id, limit, offset, from_time, to_time)
+                            }}}}
+                        }}}}
+                    }}}}
+                }}}}
+            }}}}
+        }}}}"""
 
 
 def get_labels_string_query_string(study_id, label_group_id,  # pylint:disable=too-many-arguments
@@ -602,30 +601,29 @@ def get_diary_study_label_groups_string(patient_id, limit, offset):
     """ % (patient_id, limit, offset)
 
 
-def get_labels_for_diary_study_query_string(patient_id, label_group_id,  # pylint:disable=too-many-arguments
-                                            from_time, to_time, limit, offset):
-    return """
-        query {
-            patient (id: "%s") {
+def get_labels_for_diary_study_paged_query_string(patient_id, label_group_id, from_time, to_time):
+    return f"""
+        query {{{{
+            patient (id: "{patient_id}") {{{{
                 id
-                diaryStudy {
-                    labelGroup (labelGroupId: "%s") {
+                diaryStudy {{{{
+                    labelGroup (labelGroupId: "{label_group_id}") {{{{
                         id
-                        labels (limit: %.0f, offset: %.0f, from: %.0f, to: %.0f) {
+                        labels (limit: {{limit}}, offset: {{offset}}, from: {from_time}, to: {to_time}) {{{{
                             id
                             startTime
                             timezone
                             duration
-                            tags {
-                                tagType {
+                            tags {{{{
+                                tagType {{{{
                                     value
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        }""" % (patient_id, label_group_id, limit, offset, from_time, to_time)
+                                }}}}
+                            }}}}
+                        }}}}
+                    }}}}
+                }}}}
+            }}}}
+        }}}}"""
 
 
 def get_diary_study_channel_groups_query_string(patient_id, from_time, to_time):
@@ -654,18 +652,18 @@ def get_diary_study_channel_groups_query_string(patient_id, from_time, to_time):
         }""" % (patient_id, from_time, to_time)
 
 
-def get_study_ids_in_study_cohort_query_string(study_cohort_id, limit, offset):
-    return """
-        query {
-            studyCohort(id: "%s") {
+def get_study_ids_in_study_cohort_paged_query_string(study_cohort_id):
+    return f"""
+        query {{{{
+            studyCohort(id: "{study_cohort_id}") {{{{
                 id
                 name
-                studies(limit: %0.f, offset: %0.f) {
+                studies(limit: {{limit}}, offset: {{offset}}) {{{{
                     id
-                }
-            }
-        }
-    """ % (study_cohort_id, limit, offset)
+                }}}}
+            }}}}
+        }}}}
+    """
 
 
 def create_study_cohort_mutation_string(name, description=None, key=None, study_ids=None):
@@ -730,39 +728,36 @@ def remove_studies_from_study_cohort_mutation_string(study_cohort_id, study_ids)
     )
 
 
-def get_mood_survey_results_query_string(survey_template_ids, limit, offset):
-    return """
-    query {
-        surveys(surveyTemplateIds: [%s], limit: %0.f, offset: %0.f) {
-            completer {
+def get_mood_survey_results_paged_query_string(survey_template_ids):
+    return f"""
+        query {{{{
+            surveys(surveyTemplateIds: {get_json_list(survey_template_ids)}, limit: {{limit}}, offset: {{offset}}) {{{{
+                completer {{{{
+                    id
+                }}}}
                 id
-            }
-            id
-            fields {
-                key
-                value
-            }
-            lastSubmittedAt
-        }
-    }
-    """ % (
-        ','.join([f'"{survey_template_id}"' for survey_template_id in survey_template_ids]),
-        limit,
-        offset
-    )
+                fields {{{{
+                    key
+                    value
+                }}}}
+                lastSubmittedAt
+            }}}}
+        }}}}
+    """
 
-def get_user_ids_in_user_cohort_query_string(user_cohort_id, limit, offset):
-    return """
-        query {
-            userCohort(id: "%s") {
+
+def get_user_ids_in_user_cohort_paged_query_string(user_cohort_id):
+    return f"""
+        query {{{{
+            userCohort(id: "{user_cohort_id}") {{{{
                 id
                 name
-                users(limit: %0.f, offset: %0.f) {
+                users(limit: {{limit}}, offset: {{offset}}) {{{{
                     id
-                }
-            }
-        }
-    """ % (user_cohort_id, limit, offset)
+                }}}}
+            }}}}
+        }}}}
+    """
 
 
 def get_create_user_cohort_mutation_string(name, description=None, key=None, user_ids=None):

--- a/seerpy/seerpy.py
+++ b/seerpy/seerpy.py
@@ -1172,7 +1172,6 @@ class SeerConnect:  # pylint: disable=too-many-public-methods
         labels = self.pandas_flatten(alerts, '', 'labels')
         return labels
 
-    # TODO: is there a reason to_time is not 9e12?
     def get_diary_medication_compliance(self, patient_id, from_time=0, to_time=0):
         """
         Get all medication compliance records for a given patient.
@@ -1184,7 +1183,8 @@ class SeerConnect:  # pylint: disable=too-many-public-methods
         from_time : int, optional
             Timestamp in msec - only retrieve data from this point onward
         to_time : int, optional
-            Timestamp in msec - only retrieve data up until this point
+            Timestamp in msec - only retrieve data up until this point. The default value of 0 means
+            up until this point in time for this query
 
         Returns
         -------

--- a/seerpy/seerpy.py
+++ b/seerpy/seerpy.py
@@ -153,8 +153,8 @@ class SeerConnect:  # pylint: disable=too-many-public-methods
         """
         For queries expecting a large number of objects returned, split query into iterative calls
         to `execute_query()`.
-        The object_path parameter controls which part of the query result is returned, and the
-        iteration_path parameter indicates where the results vary for each iteration.
+        The object_path parameter controls which part of the query response is returned, and the
+        iteration_path parameter indicates where the response can vary for each iteration.
 
         Parameters
         ----------
@@ -164,13 +164,13 @@ class SeerConnect:  # pylint: disable=too-many-public-methods
             Batch size for repeated API calls
         object_path : list of str
             One or more levels of key giving the path to the object to be returned
-            e.g. ['userCohort', 'users'] for a query result of
+            e.g. ['userCohort', 'users'] for a query response of
             {"userCohort": {"users": [{"id": "user1"}, {"id": "user2"}]}}
             would give [{"id": "user1"}, {"id": "user2"}]
         iteration_path : list of str, optional
-            None (default), one, or more levels of key giving the path to the node where results
-            can vary with each query iteration. If None then the results vary at the path given
-            by object_keys
+            None (default), one, or more levels of key giving the path to the node where the
+            response can vary with each query iteration. If None then the response varies at the
+            path given by object_path
         party_id : str, optional
             The organisation/entity to specify for the query
 
@@ -186,12 +186,12 @@ class SeerConnect:  # pylint: disable=too-many-public-methods
             formatted_query_string = query_string.format(limit=limit, offset=offset)
             response = self.execute_query(formatted_query_string, party_id)
 
-            # select the part of the result we are interested in
+            # select the part of the response we are interested in
             for key in object_path:
                 response = response[key]
 
             # select the part of the response which can vary. if iteration_path is None this will be
-            # the same as the part of the result we are interested in
+            # the same as the part of the response we are interested in
             response_increment = response
             if iteration_path:
                 for key in iteration_path:
@@ -201,10 +201,10 @@ class SeerConnect:  # pylint: disable=too-many-public-methods
                 break
 
             if not result:
-            # if this is the first response, save the whole thing
+            # if this is the first response, save it
                 result = response
             else:
-                # otherwise add the response increment to the existing response at the correct level
+                # otherwise add the response increment to the existing result at the correct level
                 result_increment_container = result
                 if iteration_path:
                     for key in iteration_path:

--- a/tests/test_seerpy.py
+++ b/tests/test_seerpy.py
@@ -286,7 +286,31 @@ class TestGetSegmentUrls:
 @mock.patch('seerpy.seerpy.SeerAuth', autospec=True)
 class TestGetLabels:
 
-    def test_success(self, seer_auth, gql_client, unused_sleep):
+    def test_success_single(self, seer_auth, gql_client, unused_sleep):
+        # setup
+        seer_auth.return_value.cookie = {DEFAULT_COOKIE_KEY: "cookie"}
+        seer_auth.return_value.get_connection_parameters.return_value = DEFAULT_CONNECTION_PARAMS
+
+        side_effects = []
+
+        with open(TEST_DATA_DIR / "labels_1.json", "r") as f:
+            query_data = json.load(f)
+        side_effects.append(query_data)
+        # this is the "no more data" response for get_labels()
+        with open(TEST_DATA_DIR / "labels_1_empty.json", "r") as f:
+            side_effects.append(json.load(f))
+
+        gql_client.return_value.execute.side_effect = side_effects
+
+        expected_result = query_data['study']
+
+        # run test
+        result = SeerConnect().get_labels("study-1-id", "label-group-1-id")
+
+        # check result
+        assert result == expected_result
+
+    def test_success_multiple(self, seer_auth, gql_client, unused_sleep):
         # setup
         seer_auth.return_value.cookie = {DEFAULT_COOKIE_KEY: "cookie"}
         seer_auth.return_value.get_connection_parameters.return_value = DEFAULT_CONNECTION_PARAMS
@@ -305,6 +329,26 @@ class TestGetLabels:
 
         with open(TEST_DATA_DIR / "labels_result.json", "r") as f:
             expected_result = json.load(f)
+
+        # run test
+        result = SeerConnect().get_labels("study-1-id", "label-group-1-id")
+
+        # check result
+        assert result == expected_result
+
+    def test_success_empty(self, seer_auth, gql_client, unused_sleep):
+        # setup
+        seer_auth.return_value.cookie = {DEFAULT_COOKIE_KEY: "cookie"}
+        seer_auth.return_value.get_connection_parameters.return_value = DEFAULT_CONNECTION_PARAMS
+
+        side_effects = []
+
+        with open(TEST_DATA_DIR / "labels_1_empty.json", "r") as f:
+            side_effects.append(json.load(f))
+
+        gql_client.return_value.execute.side_effect = side_effects
+
+        expected_result = []
 
         # run test
         result = SeerConnect().get_labels("study-1-id", "label-group-1-id")

--- a/tests/test_seerpy.py
+++ b/tests/test_seerpy.py
@@ -661,3 +661,41 @@ class TestUserCohorts:
             }
         }
     """
+
+
+@mock.patch('time.sleep', return_value=None)
+@mock.patch('seerpy.seerpy.GQLClient', autospec=True)
+@mock.patch('seerpy.seerpy.SeerAuth', autospec=True)
+class TestGetTagIds:
+    def test_success(self, seer_auth, gql_client, unused_sleep):
+        # setup
+        seer_auth.return_value.cookie = {DEFAULT_COOKIE_KEY: "cookie"}
+        seer_auth.return_value.get_connection_parameters.return_value = DEFAULT_CONNECTION_PARAMS
+
+        expected_result = [
+            {'category': {'description': None, 'id': 'algorithm', 'name': 'Algorithm'},
+             'forDiary': None, 'forStudy': True, 'id': 'tag-1-id', 'value': 'Needs Review'},
+            {'category': {'description': None, 'id': 'algorithm', 'name': 'Algorithm'},
+             'forDiary': None, 'forStudy': False, 'id': 'tag-2-id', 'value': 'Epileptiform'}
+        ]
+        gql_client.return_value.execute.return_value = {'labelTags': expected_result}
+
+        # run test
+        result = SeerConnect().get_tag_ids()
+
+        # check result
+        assert result == expected_result
+
+    def test_empty(self, seer_auth, gql_client, unused_sleep):
+        # setup
+        seer_auth.return_value.cookie = {DEFAULT_COOKIE_KEY: "cookie"}
+        seer_auth.return_value.get_connection_parameters.return_value = DEFAULT_CONNECTION_PARAMS
+
+        expected_result = []
+        gql_client.return_value.execute.return_value = {'labelTags': expected_result}
+
+        # run test
+        result = SeerConnect().get_tag_ids()
+
+        # check result
+        assert result == expected_result


### PR DESCRIPTION
Makes get_paginated_response more flexible so it can replace custom implementations of paginated responses. All tests still pass and I have added a couple more, but not all code is tested so please let me know if it breaks anything in use.

Also standardised the way non paginated calls are made.

get_diary_labels is not catered for by get_paginated_response. I'm still thinking about whether it's worth changing get_paginated_response for that case.