### PR TITLE
Change location of call to login details

### DIFF
--- a/seerpy/auth.py
+++ b/seerpy/auth.py
@@ -86,10 +86,10 @@ class SeerAuth(BaseAuth):
         }
 
     def login(self):
-        login_url = self.api_url + '/auth/login'
         if not self.email or not self.password:
             self._login_details()
         body = {'email': self.email, 'password': self.password}
+        login_url = self.api_url + '/auth/login'
         response = requests.post(url=login_url, data=body)
         print("login status_code", response.status_code)
         if (response.status_code == requests.codes.ok  # pylint: disable=maybe-no-member
@@ -117,8 +117,6 @@ class SeerAuth(BaseAuth):
         allowed_attempts = 3
 
         for i in range(allowed_attempts):
-            if not self.email or not self.password:
-                self._login_details()
             self.login()
             response = self._verify_login()
 

--- a/seerpy/auth.py
+++ b/seerpy/auth.py
@@ -87,6 +87,8 @@ class SeerAuth(BaseAuth):
 
     def login(self):
         login_url = self.api_url + '/auth/login'
+        if not self.email or not self.password:
+            self._login_details()
         body = {'email': self.email, 'password': self.password}
         response = requests.post(url=login_url, data=body)
         print("login status_code", response.status_code)


### PR DESCRIPTION
Fixes a bug where it's possible to get through auth init without collecting email and password (if a valid cookie is stored), and if we have to re-auth at some point (if the session expires) the call to login will fail.