### PR TITLE
Fix TypeError when calling `pandas_flatten()` on DF with missing values

### DIFF
--- a/seerpy/seerpy.py
+++ b/seerpy/seerpy.py
@@ -254,13 +254,15 @@ class SeerConnect:  # pylint: disable=too-many-public-methods
         child_list = []
         for i in range(len(parent)):
             parent_id = parent[parent_name+'id'][i]
-            child = json_normalize(parent[parent_name+child_name][i]).sort_index(axis=1)
-            child.columns = [child_name+'.' + str(col) for col in child.columns]
-            child[parent_name+'id'] = parent_id
-            child_list.append(child)
+            cell_to_flatten = parent[parent_name+child_name][i]
+            if isinstance(cell_to_flatten, list):
+                child = json_normalize(cell_to_flatten).sort_index(axis=1)
+                child.columns = [child_name+'.' + str(col) for col in child.columns]
+                child[parent_name+'id'] = parent_id
+                child_list.append(child)
 
         if child_list:
-            child = pd.concat(child_list).reset_index(drop=True)
+            child = pd.concat(child_list).reset_index(drop=True, sort=True)
         if not child_list or child.empty:
             columns = [parent_name + 'id', child_name + '.id']
             child = pd.DataFrame(columns=columns)

--- a/seerpy/seerpy.py
+++ b/seerpy/seerpy.py
@@ -262,7 +262,7 @@ class SeerConnect:  # pylint: disable=too-many-public-methods
                 child_list.append(child)
 
         if child_list:
-            child = pd.concat(child_list).reset_index(drop=True, sort=True)
+            child = pd.concat(child_list, sort=True).reset_index(drop=True)
         if not child_list or child.empty:
             columns = [parent_name + 'id', child_name + '.id']
             child = pd.DataFrame(columns=columns)


### PR DESCRIPTION
Calling `SeerConnect.pandas_flatten` raises a `TypeError` when the `child_name` column of the `parent` DataFrame has any missing values. E.g. Calling `SeerConnect.get_all_bookings_dataframe()` currently hits this issue, as there are recent bookings with no `patient.studies` value.

The exception is thrown by Pandas trying to iterate over a non-iterable (`math.nan` values in the case of the bookings data). As such, skip cells that don't contains a list.

Not sure if this is the best solution, e.g. should we also allow tuples or iterables generally using `collections.Iterable`?

I also tried:
```python
try:
    child = json_normalize(cell_to_flatten).sort_index(axis=1)
except TypeError:
```
However this doesn't catch the internal Pandas exception.

And:
```python
if math.isnan(cell_to_flatten):
    continue
```
However this raises a `TypeError` when it gets a list (i.e. what's expected) rather than a number/NaN.