### PR TITLE
Support passing variable_values to SeerConnect.execute_query

### DIFF
--- a/seerpy/seerpy.py
+++ b/seerpy/seerpy.py
@@ -96,7 +96,7 @@ class SeerConnect:  # pylint: disable=too-many-public-methods
         self.graphql_client = graphql_client
         self.last_query_time = time.time()
 
-    def execute_query(self, query_string, party_id=None, invocations=0):
+    def execute_query(self, query_string, party_id=None, invocations=0, variable_values=None):
         """
         Execute a GraphQL query and return response. Handle retrying upon
         failure and rate limiting requests.
@@ -125,7 +125,9 @@ class SeerConnect:  # pylint: disable=too-many-public-methods
         try:
             time.sleep(max(0, ((self.api_limit_expire / self.api_limit)
                                - (time.time() - self.last_query_time))))
-            response = self.graphql_client(party_id).execute(gql(query_string))
+            response = self.graphql_client(party_id).execute(
+                gql(query_string),
+                variable_values=variable_values)
             self.last_query_time = time.time()
             return response
         except Exception as ex:
@@ -144,7 +146,11 @@ class SeerConnect:  # pylint: disable=too-many-public-methods
                 invocations += 1
 
                 self.seer_auth.login()
-                return self.execute_query(query_string, party_id, invocations=invocations)
+                return self.execute_query(
+                    query_string,
+                    party_id,
+                    invocations=invocations,
+                    variable_values=variable_values)
 
             raise
 

--- a/tests/test_seerpy.py
+++ b/tests/test_seerpy.py
@@ -47,51 +47,30 @@ class TestSeerConnect:
 @mock.patch('seerpy.seerpy.GQLClient', autospec=True)
 @mock.patch('seerpy.seerpy.SeerAuth', autospec=True)
 class TestPassingQueryVariables:
-    @staticmethod
-    def build_query_responder(results):
-        """
-        This testing utility allows returning multiple errors / query arguments as side effects.
-        """
-        index = -1
-
-        def log_side_effects_and_return(_args, variable_values):
-            nonlocal index
-
-            if index >= len(results):
-                return None
-
-            index += 1
-
-            if results[index] is None:
-                return variable_values
-
-            raise results[index]
-
-        return log_side_effects_and_return
-
     def test_query_variables_are_passed(self, seer_auth, gql_client, unused_sleep):
         seer_auth.return_value.cookie = {DEFAULT_COOKIE_KEY: "cookie"}
         seer_auth.return_value.get_connection_parameters.return_value = DEFAULT_CONNECTION_PARAMS
 
-        gql_client.return_value.execute.side_effect = \
-            TestPassingQueryVariables.build_query_responder([None])
+        gql_client.return_value.execute.side_effect = [None]
 
-        result = SeerConnect().execute_query("query Q { test { id } }", variable_values={'a': 'b'})
-        assert result == {'a': 'b'}
+        SeerConnect().execute_query("query Q { test { id } }", variable_values={'a': 'b'})
+        assert gql_client.return_value.execute.call_count == 1
+        assert gql_client.return_value.execute.call_args[1]['variable_values'] == {'a': 'b'}
 
     def test_query_variables_are_passed_on_initial_failure(self, seer_auth, gql_client,
                                                            unused_sleep):
         seer_auth.return_value.cookie = {DEFAULT_COOKIE_KEY: "cookie"}
         seer_auth.return_value.get_connection_parameters.return_value = DEFAULT_CONNECTION_PARAMS
 
-        gql_client.return_value.execute.side_effect = \
-            TestPassingQueryVariables.build_query_responder([
-                Exception('503 Server Error'),
-                None
-            ])
+        gql_client.return_value.execute.side_effect = [
+            Exception('503 Server Error'),
+            None
+        ]
 
-        result = SeerConnect().execute_query("query Q { test { id } }", variable_values={'a': 'b'})
-        assert result == {'a': 'b'}
+        SeerConnect().execute_query("query Q { test { id } }", variable_values={'a': 'b'})
+
+        assert gql_client.return_value.execute.call_count == 2
+        assert gql_client.return_value.execute.call_args[1]['variable_values'] == {'a': 'b'}
 
 
 @mock.patch.object(SeerConnect, "get_all_study_metadata_by_ids", autospec=True)

--- a/tests/test_seerpy.py
+++ b/tests/test_seerpy.py
@@ -43,6 +43,57 @@ class TestSeerConnect:
             SeerConnect()
 
 
+@mock.patch('time.sleep', return_value=None)
+@mock.patch('seerpy.seerpy.GQLClient', autospec=True)
+@mock.patch('seerpy.seerpy.SeerAuth', autospec=True)
+class TestPassingQueryVariables:
+    @staticmethod
+    def build_query_responder(results):
+        """
+        This testing utility allows returning multiple errors / query arguments as side effects.
+        """
+        index = -1
+
+        def log_side_effects_and_return(_args, variable_values):
+            nonlocal index
+
+            if index >= len(results):
+                return None
+
+            index += 1
+
+            if results[index] is None:
+                return variable_values
+
+            raise results[index]
+
+        return log_side_effects_and_return
+
+    def test_query_variables_are_passed(self, seer_auth, gql_client, unused_sleep):
+        seer_auth.return_value.cookie = {DEFAULT_COOKIE_KEY: "cookie"}
+        seer_auth.return_value.get_connection_parameters.return_value = DEFAULT_CONNECTION_PARAMS
+
+        gql_client.return_value.execute.side_effect = \
+            TestPassingQueryVariables.build_query_responder([None])
+
+        result = SeerConnect().execute_query("query Q { test { id } }", variable_values={'a': 'b'})
+        assert result == {'a': 'b'}
+
+    def test_query_variables_are_passed_on_initial_failure(self, seer_auth, gql_client,
+                                                           unused_sleep):
+        seer_auth.return_value.cookie = {DEFAULT_COOKIE_KEY: "cookie"}
+        seer_auth.return_value.get_connection_parameters.return_value = DEFAULT_CONNECTION_PARAMS
+
+        gql_client.return_value.execute.side_effect = \
+            TestPassingQueryVariables.build_query_responder([
+                Exception('503 Server Error'),
+                None
+            ])
+
+        result = SeerConnect().execute_query("query Q { test { id } }", variable_values={'a': 'b'})
+        assert result == {'a': 'b'}
+
+
 @mock.patch.object(SeerConnect, "get_all_study_metadata_by_ids", autospec=True)
 @mock.patch.object(SeerConnect, "__init__", autospec=True, return_value=None)
 class TestGetAllStudyMetaDataDataframeByIds:


### PR DESCRIPTION
This allows external callers to use variables instead of string interpolation.

Existing queries are untouched.