### PR TITLE
Add missing comma in error names

### DIFF
--- a/seerpy/seerpy.py
+++ b/seerpy/seerpy.py
@@ -119,7 +119,7 @@ class SeerConnect:  # pylint: disable=too-many-public-methods
         -----
         See queries in graphql.py for structure of results returned
         """
-        resolvable_api_errors = ['502 Server Error', '503 Server Error', '504 Server Error'
+        resolvable_api_errors = ['502 Server Error', '503 Server Error', '504 Server Error',
                                  'Read timed out.', 'NOT_AUTHENTICATED']
 
         try:


### PR DESCRIPTION
There was a missing comma in the acceptable error names list, meaning that 504 errors were not matched.

This PR adds one (1) comma.