### PR TITLE
fix add label using graphql variables

### DIFF
--- a/seerpy/graphql.py
+++ b/seerpy/graphql.py
@@ -1,9 +1,80 @@
 """
 GraphQL queries used by various seerpy.SeerConnect methods.
 """
-import json
-
 from . import utils
+
+
+def get_json_list(list_of_strings, include_brackets=True):
+    """
+    Convert a list of strings into a single string representation, suitable for
+    inclusion in GraphQL queries.
+
+    Parameters
+    ---------
+    list_of_strings : list of str
+        Strings to convert to single string
+    include_backets : bool
+        Whether to include square braces in the returned string
+
+    Returns
+    -------
+    stringified_list : str
+        String representation of the input list
+
+    Example
+    -------
+    >>> get_json_list(['cat', 'dog'])
+    '["cat", "dog"]'
+
+    >>> get_json_list(['cat', 'dog'], include_brackets=False)
+    '"cat", "dog"'
+    """
+    json_list = ', '.join('"%s"' % string for string in list_of_strings)
+    if include_brackets:
+        json_list = '[' + json_list + ']'
+    return json_list
+
+
+def get_string_from_list_of_dicts(list_of_dicts):
+    """
+    Convert a list of dicts into a flattened string representation.
+
+    Parameters
+    ---------
+    list_of_dicts : list of dict
+        Arbitrary dictionaries to convert to string
+
+    Returns
+    -------
+    stringified_dicts : str
+        String representation of the input list of dicts
+
+    Example
+    -------
+    >>> dicts = [{'a': 'this', 'b': 'that', 'c': {'the other'}}, {'d': 'then'}]
+    >>> get_string_from_list_of_dicts(dicts)
+    ' { a: "this", b: "that", c: {\'the other\'}}, { d: "then"}'
+    """
+    labels_string = ''
+    for d in list_of_dicts:
+        labels_string += ' {'
+        for k in d.keys():
+            if d[k] is None:
+                continue
+            labels_string += ' ' + k + ': '
+            if isinstance(d[k], str):
+                labels_string += '"' + d[k] + '",'
+            elif isinstance(d[k], dict):
+                labels_string += get_string_from_list_of_dicts(list(d[k]))
+            elif isinstance(d[k], list):
+                if d[k]:
+                    labels_string += (get_json_list(d[k]) + ",")
+            else:
+                labels_string += str(d[k]) + ','
+        labels_string = labels_string[:-1]  # remove last comma
+        labels_string += '},'
+    labels_string = labels_string[:-1]  # remove last comma
+    return labels_string
 
 
 def get_study_with_data_query_string(study_id):
@@ -114,9 +185,11 @@ def get_labels_string_query_string(study_id, label_group_id, from_time, to_time)
 
 
 def get_label_groups_for_study_ids_paged_query_string(study_ids):
+    study_ids_string = get_json_list(study_ids)
+
     return f"""
         query {{{{
-            studies (limit: {{limit}}, offset: {{offset}}, studyIds: {json.dumps(study_ids)}) {{{{
+            studies (limit: {{limit}}, offset: {{offset}}, studyIds: {study_ids_string}) {{{{
                 id
                 name
                 labelGroups {{{{
@@ -151,16 +224,19 @@ def get_channel_groups_query_string(study_id):
 
 #    studyChannelGroupSegments
 def get_segment_urls_query_string(segment_ids):
+    segment_ids_string = get_json_list(segment_ids)
+
     return """
         query {
             studyChannelGroupSegments(segmentIds: %s) {
                 id
                 baseDataChunkUrl
             }
-        }""" % json.dumps(segment_ids)
+        }""" % segment_ids_string
 
 
 def get_data_chunk_urls_query_string(data_chunks, s3_urls=True):
+    chunk_keys = get_string_from_list_of_dicts(data_chunks)
     s3_urls = 'true' if s3_urls else 'false'
     return """
         query {
@@ -168,7 +244,7 @@ def get_data_chunk_urls_query_string(data_chunks, s3_urls=True):
                     chunkKeys: [%s],
                     s3Urls: %s
                     )
-        }""" % (json.dumps(data_chunks), s3_urls)
+        }""" % (chunk_keys, s3_urls)
 
 
 def get_studies_by_search_term_paged_query_string(search_term):
@@ -188,9 +264,11 @@ def get_studies_by_search_term_paged_query_string(search_term):
 
 
 def get_studies_by_study_id_paged_query_string(study_ids):
+    study_ids_string = get_json_list(study_ids)
+
     return f"""
         query {{{{
-            studies (limit: {{limit}}, offset: {{offset}}, studyIds: {json.dumps(study_ids)}) {{{{
+            studies (limit: {{limit}}, offset: {{offset}}, studyIds: {study_ids_string}) {{{{
                 id
                 name
                 patient {{{{
@@ -204,6 +282,8 @@ def get_studies_by_study_id_paged_query_string(study_ids):
 
 
 def get_add_labels_mutation_string(group_id, labels):
+    labels_string = get_string_from_list_of_dicts(labels)
+
     return """
         mutation {
             addLabelsToLabelGroup(
@@ -212,7 +292,7 @@ def get_add_labels_mutation_string(group_id, labels):
             ) {
                 id
             }
-        }""" % (group_id, json.dumps(labels))
+        }""" % (group_id, labels_string)
 
 
 def get_tag_id_query_string():
@@ -316,12 +396,12 @@ def get_patients_query_string():
             }
         }"""
 
-
+  
 def get_diary_insights_paged_query_string(patient_id, limit, offset):
     return f"""
         query {{{{
             patient (id: "{patient_id}") {{{{
-                id
+                id	
                 insights (limit: {{limit}}, offset: {{offset}}) {{{{
                     id
                     report {{{{
@@ -444,9 +524,11 @@ def get_diary_medication_compliance_query_string(patient_id, from_time, to_time)
 
 
 def get_documents_for_study_ids_paged_query_string(study_ids):
+    study_ids_string = get_json_list(study_ids)
+
     return f"""
         query {{{{
-            studies (limit: {{limit}}, offset: {{offset}}, studyIds: {json.dumps(study_ids)}) {{{{
+            studies (limit: {{limit}}, offset: {{offset}}, studyIds: {study_ids_string}) {{{{
                 id
                 name
                 documents {{{{
@@ -625,7 +707,7 @@ def create_study_cohort_mutation_string(name, description=None, key=None, study_
         args.append(('key', utils.quote_str(key)))
 
     if study_ids is not None:
-        args.append(('studyIds', json.dumps(study_ids)))
+        args.append(('studyIds', get_json_list(study_ids)))
 
     return """
         mutation {
@@ -652,7 +734,7 @@ def add_studies_to_study_cohort_mutation_string(study_cohort_id, study_ids):
                 }
             }
         }
-    """ % (study_cohort_id, json.dumps(study_ids))
+    """ % (study_cohort_id, get_json_list(study_ids))
 
 
 def remove_studies_from_study_cohort_mutation_string(study_cohort_id, study_ids):
@@ -667,13 +749,13 @@ def remove_studies_from_study_cohort_mutation_string(study_cohort_id, study_ids)
                 }
             }
         }
-    """ % (study_cohort_id, json.dumps(study_ids))
+    """ % (study_cohort_id, get_json_list(study_ids))
 
 
 def get_mood_survey_results_paged_query_string(survey_template_ids):
     return f"""
         query {{{{
-            surveys(surveyTemplateIds: {json.dumps(survey_template_ids)}, limit: {{limit}}, offset: {{offset}}) {{{{
+            surveys(surveyTemplateIds: {get_json_list(survey_template_ids)}, limit: {{limit}}, offset: {{offset}}) {{{{
                 completer {{{{
                     id
                 }}}}
@@ -712,7 +794,7 @@ def get_create_user_cohort_mutation_string(name, description=None, key=None, use
         args.append(('key', utils.quote_str(key)))
 
     if user_ids is not None:
-        args.append(('userIds', json.dumps(user_ids)))
+        args.append(('userIds', get_json_list(user_ids)))
 
     return """
         mutation {
@@ -739,7 +821,7 @@ def get_add_users_to_user_cohort_mutation_string(user_cohort_id, user_ids):
                 }
             }
         }
-    """ % (user_cohort_id, json.dumps(user_ids))
+    """ % (user_cohort_id, get_json_list(user_ids))
 
 
 def get_remove_users_from_user_cohort_mutation_string(user_cohort_id, user_ids):
@@ -754,4 +836,4 @@ def get_remove_users_from_user_cohort_mutation_string(user_cohort_id, user_ids):
                 }
             }
         }
-    """ % (user_cohort_id, json.dumps(user_ids))
+    """ % (user_cohort_id, get_json_list(user_ids))

--- a/seerpy/graphql.py
+++ b/seerpy/graphql.py
@@ -281,18 +281,15 @@ def get_studies_by_study_id_paged_query_string(study_ids):
         }}}}"""
 
 
-def get_add_labels_mutation_string(group_id, labels):
-    labels_string = get_string_from_list_of_dicts(labels)
-
+def get_add_labels_mutation_string():
     return """
-        mutation {
-            addLabelsToLabelGroup(
-                groupId: "%s",
-                labels: [%s]
-            ) {
+        mutation addLabelsToLabelGroup($groupId: String,
+                                       $labels: [NewStudyLabel]) {
+            addLabelsToLabelGroup(groupId: $groupId,
+                                  labels: $labels) {
                 id
             }
-        }""" % (group_id, labels_string)
+        }"""
 
 
 def get_tag_id_query_string():
@@ -396,12 +393,12 @@ def get_patients_query_string():
             }
         }"""
 
-  
+
 def get_diary_insights_paged_query_string(patient_id, limit, offset):
     return f"""
         query {{{{
             patient (id: "{patient_id}") {{{{
-                id	
+                id
                 insights (limit: {{limit}}, offset: {{offset}}) {{{{
                     id
                     report {{{{

--- a/seerpy/graphql.py
+++ b/seerpy/graphql.py
@@ -283,8 +283,8 @@ def get_studies_by_study_id_paged_query_string(study_ids):
 
 def get_add_labels_mutation_string():
     return """
-        mutation addLabelsToLabelGroup($groupId: String,
-                                       $labels: [NewStudyLabel]) {
+        mutation addLabelsToLabelGroup($groupId: String!,
+                                       $labels: [NewStudyLabel]!) {
             addLabelsToLabelGroup(groupId: $groupId,
                                   labels: $labels) {
                 id

--- a/seerpy/graphql.py
+++ b/seerpy/graphql.py
@@ -1,80 +1,9 @@
 """
 GraphQL queries used by various seerpy.SeerConnect methods.
 """
+import json
+
 from . import utils
-
-
-def get_json_list(list_of_strings, include_brackets=True):
-    """
-    Convert a list of strings into a single string representation, suitable for
-    inclusion in GraphQL queries.
-
-    Parameters
-    ---------
-    list_of_strings : list of str
-        Strings to convert to single string
-    include_backets : bool
-        Whether to include square braces in the returned string
-
-    Returns
-    -------
-    stringified_list : str
-        String representation of the input list
-
-    Example
-    -------
-    >>> get_json_list(['cat', 'dog'])
-    '["cat", "dog"]'
-
-    >>> get_json_list(['cat', 'dog'], include_brackets=False)
-    '"cat", "dog"'
-    """
-    json_list = ', '.join('"%s"' % string for string in list_of_strings)
-    if include_brackets:
-        json_list = '[' + json_list + ']'
-    return json_list
-
-
-def get_string_from_list_of_dicts(list_of_dicts):
-    """
-    Convert a list of dicts into a flattened string representation.
-
-    Parameters
-    ---------
-    list_of_dicts : list of dict
-        Arbitrary dictionaries to convert to string
-
-    Returns
-    -------
-    stringified_dicts : str
-        String representation of the input list of dicts
-
-    Example
-    -------
-    >>> dicts = [{'a': 'this', 'b': 'that', 'c': {'the other'}}, {'d': 'then'}]
-    >>> get_string_from_list_of_dicts(dicts)
-    ' { a: "this", b: "that", c: {\'the other\'}}, { d: "then"}'
-    """
-    labels_string = ''
-    for d in list_of_dicts:
-        labels_string += ' {'
-        for k in d.keys():
-            if d[k] is None:
-                continue
-            labels_string += ' ' + k + ': '
-            if isinstance(d[k], str):
-                labels_string += '"' + d[k] + '",'
-            elif isinstance(d[k], dict):
-                labels_string += get_string_from_list_of_dicts(list(d[k]))
-            elif isinstance(d[k], list):
-                if d[k]:
-                    labels_string += (get_json_list(d[k]) + ",")
-            else:
-                labels_string += str(d[k]) + ','
-        labels_string = labels_string[:-1]  # remove last comma
-        labels_string += '},'
-    labels_string = labels_string[:-1]  # remove last comma
-    return labels_string
 
 
 def get_study_with_data_query_string(study_id):
@@ -185,11 +114,9 @@ def get_labels_string_query_string(study_id, label_group_id, from_time, to_time)
 
 
 def get_label_groups_for_study_ids_paged_query_string(study_ids):
-    study_ids_string = get_json_list(study_ids)
-
     return f"""
         query {{{{
-            studies (limit: {{limit}}, offset: {{offset}}, studyIds: {study_ids_string}) {{{{
+            studies (limit: {{limit}}, offset: {{offset}}, studyIds: {json.dumps(study_ids)}) {{{{
                 id
                 name
                 labelGroups {{{{
@@ -224,19 +151,16 @@ def get_channel_groups_query_string(study_id):
 
 #    studyChannelGroupSegments
 def get_segment_urls_query_string(segment_ids):
-    segment_ids_string = get_json_list(segment_ids)
-
     return """
         query {
             studyChannelGroupSegments(segmentIds: %s) {
                 id
                 baseDataChunkUrl
             }
-        }""" % segment_ids_string
+        }""" % json.dumps(segment_ids)
 
 
 def get_data_chunk_urls_query_string(data_chunks, s3_urls=True):
-    chunk_keys = get_string_from_list_of_dicts(data_chunks)
     s3_urls = 'true' if s3_urls else 'false'
     return """
         query {
@@ -244,7 +168,7 @@ def get_data_chunk_urls_query_string(data_chunks, s3_urls=True):
                     chunkKeys: [%s],
                     s3Urls: %s
                     )
-        }""" % (chunk_keys, s3_urls)
+        }""" % (json.dumps(data_chunks), s3_urls)
 
 
 def get_studies_by_search_term_paged_query_string(search_term):
@@ -264,11 +188,9 @@ def get_studies_by_search_term_paged_query_string(search_term):
 
 
 def get_studies_by_study_id_paged_query_string(study_ids):
-    study_ids_string = get_json_list(study_ids)
-
     return f"""
         query {{{{
-            studies (limit: {{limit}}, offset: {{offset}}, studyIds: {study_ids_string}) {{{{
+            studies (limit: {{limit}}, offset: {{offset}}, studyIds: {json.dumps(study_ids)}) {{{{
                 id
                 name
                 patient {{{{
@@ -282,8 +204,6 @@ def get_studies_by_study_id_paged_query_string(study_ids):
 
 
 def get_add_labels_mutation_string(group_id, labels):
-    labels_string = get_string_from_list_of_dicts(labels)
-
     return """
         mutation {
             addLabelsToLabelGroup(
@@ -292,7 +212,7 @@ def get_add_labels_mutation_string(group_id, labels):
             ) {
                 id
             }
-        }""" % (group_id, labels_string)
+        }""" % (group_id, json.dumps(labels))
 
 
 def get_tag_id_query_string():
@@ -396,12 +316,12 @@ def get_patients_query_string():
             }
         }"""
 
-  
+
 def get_diary_insights_paged_query_string(patient_id, limit, offset):
     return f"""
         query {{{{
             patient (id: "{patient_id}") {{{{
-                id	
+                id
                 insights (limit: {{limit}}, offset: {{offset}}) {{{{
                     id
                     report {{{{
@@ -524,11 +444,9 @@ def get_diary_medication_compliance_query_string(patient_id, from_time, to_time)
 
 
 def get_documents_for_study_ids_paged_query_string(study_ids):
-    study_ids_string = get_json_list(study_ids)
-
     return f"""
         query {{{{
-            studies (limit: {{limit}}, offset: {{offset}}, studyIds: {study_ids_string}) {{{{
+            studies (limit: {{limit}}, offset: {{offset}}, studyIds: {json.dumps(study_ids)}) {{{{
                 id
                 name
                 documents {{{{
@@ -707,7 +625,7 @@ def create_study_cohort_mutation_string(name, description=None, key=None, study_
         args.append(('key', utils.quote_str(key)))
 
     if study_ids is not None:
-        args.append(('studyIds', get_json_list(study_ids)))
+        args.append(('studyIds', json.dumps(study_ids)))
 
     return """
         mutation {
@@ -734,7 +652,7 @@ def add_studies_to_study_cohort_mutation_string(study_cohort_id, study_ids):
                 }
             }
         }
-    """ % (study_cohort_id, get_json_list(study_ids))
+    """ % (study_cohort_id, json.dumps(study_ids))
 
 
 def remove_studies_from_study_cohort_mutation_string(study_cohort_id, study_ids):
@@ -749,13 +667,13 @@ def remove_studies_from_study_cohort_mutation_string(study_cohort_id, study_ids)
                 }
             }
         }
-    """ % (study_cohort_id, get_json_list(study_ids))
+    """ % (study_cohort_id, json.dumps(study_ids))
 
 
 def get_mood_survey_results_paged_query_string(survey_template_ids):
     return f"""
         query {{{{
-            surveys(surveyTemplateIds: {get_json_list(survey_template_ids)}, limit: {{limit}}, offset: {{offset}}) {{{{
+            surveys(surveyTemplateIds: {json.dumps(survey_template_ids)}, limit: {{limit}}, offset: {{offset}}) {{{{
                 completer {{{{
                     id
                 }}}}
@@ -794,7 +712,7 @@ def get_create_user_cohort_mutation_string(name, description=None, key=None, use
         args.append(('key', utils.quote_str(key)))
 
     if user_ids is not None:
-        args.append(('userIds', get_json_list(user_ids)))
+        args.append(('userIds', json.dumps(user_ids)))
 
     return """
         mutation {
@@ -821,7 +739,7 @@ def get_add_users_to_user_cohort_mutation_string(user_cohort_id, user_ids):
                 }
             }
         }
-    """ % (user_cohort_id, get_json_list(user_ids))
+    """ % (user_cohort_id, json.dumps(user_ids))
 
 
 def get_remove_users_from_user_cohort_mutation_string(user_cohort_id, user_ids):
@@ -836,4 +754,4 @@ def get_remove_users_from_user_cohort_mutation_string(user_cohort_id, user_ids):
                 }
             }
         }
-    """ % (user_cohort_id, get_json_list(user_ids))
+    """ % (user_cohort_id, json.dumps(user_ids))

--- a/seerpy/seerpy.py
+++ b/seerpy/seerpy.py
@@ -370,8 +370,9 @@ class SeerConnect:  # pylint: disable=too-many-public-methods
         """
         if isinstance(labels, pd.DataFrame):
             labels = labels.to_dict('records')
-        query_string = graphql.get_add_labels_mutation_string(group_id, labels)
-        return self.execute_query(query_string)
+        query_string = graphql.get_add_labels_mutation_string()
+        return self.execute_query(query_string,
+                                  variable_values={"groupId": group_id, "labels": labels})
 
     def add_document(self, study_id, document_name, document_path):
         """


### PR DESCRIPTION
Matias had a problem adding labels with "\n" in them - the way we were (not) encoding them meant that we were submitting non-conformant graphql.
I have changed the add_label mutation to use graphql variables (thanks @seerwill) instead of directly inserting the strings into the query.
This is something we should do elsewhere as well, but I just wanted to get this change in for Matias, and also to make the change manageable.