### PR TITLE
Don't clear password unless get 401 error

### DIFF
--- a/seerpy/auth.py
+++ b/seerpy/auth.py
@@ -6,6 +6,7 @@ Copyright 2017 Seer Medical Pty Ltd, Inc. or its affiliates. All Rights Reserved
 import getpass
 import os
 import json
+import random
 import time
 
 import requests
@@ -132,8 +133,9 @@ class SeerAuth(BaseAuth):
                 self.cookie = None
                 self.password = None
             else:
-                sleep_time = (allowed_attempts + 3)**2
-                print('\nLogin failed, retrying in', sleep_time, 'seconds...')
+                # Sleep for ~5, 20, 60 seconds, with jitter to avoid thundering heard problem
+                sleep_time = 5 + 5 * i + 11 * i**2 + random.uniform(0, 5)
+                print(f'\nLogin failed, retrying in {sleep_time:d} seconds...')
                 time.sleep(sleep_time)
 
     def _verify_login(self):


### PR DESCRIPTION
If authentication fails, only ask user to re-enter password/read password from file again if the status code returned was a 401 (unauthorized).

For any other "non-ok" status code (e.g. 429 timeout, 502 bad gateway), for each retry sleep for an exponentially increasing period of time then try again with same password.

Sleep time calibrated to be roughly 5/20/60 seconds, with a random few seconds added to avoid the [thundering heard problem](https://www.apollographql.com/docs/link/links/retry/#avoiding-thundering-herd).