### PR TITLE
Fix bad chunk size

### DIFF
--- a/seerpy/utils.py
+++ b/seerpy/utils.py
@@ -101,10 +101,15 @@ def download_channel_data(data_q, download_function):
         data['channelGroups.id'] = channel_groups_id
         data['segments.id'] = segments_id
         data = data[['time', 'id', 'channelGroups.id', 'segments.id'] + channel_names]
+
+        # data chunks seem to always be 10 seconds even if they don't contain that much data
+        # also caters for case where the data we want doesn't line up with start and end of chunks
         segment_start = meta_data['segments.startTime']
         segment_end = segment_start + meta_data['segments.duration']
         data = data[(data['time'] >= segment_start) & (data['time'] < segment_end)]
+
         return data
+
     except Exception as ex:
         print(ex)
         print(study_id)

--- a/seerpy/utils.py
+++ b/seerpy/utils.py
@@ -103,7 +103,6 @@ def download_channel_data(data_q, download_function):
         data = data[['time', 'id', 'channelGroups.id', 'segments.id'] + channel_names]
 
         # data chunks seem to always be 10 seconds even if they don't contain that much data
-        # also caters for case where the data we want doesn't line up with start and end of chunks
         segment_start = meta_data['segments.startTime']
         segment_end = segment_start + meta_data['segments.duration']
         data = data[(data['time'] >= segment_start) & (data['time'] < segment_end)]

--- a/seerpy/utils.py
+++ b/seerpy/utils.py
@@ -101,6 +101,9 @@ def download_channel_data(data_q, download_function):
         data['channelGroups.id'] = channel_groups_id
         data['segments.id'] = segments_id
         data = data[['time', 'id', 'channelGroups.id', 'segments.id'] + channel_names]
+        segment_start = meta_data['segments.startTime']
+        segment_end = segment_start + meta_data['segments.duration']
+        data = data[(data['time'] >= segment_start) & (data['time'] < segment_end)]
         return data
     except Exception as ex:
         print(ex)
@@ -159,7 +162,7 @@ def create_data_chunk_urls(metadata, segment_urls, from_time=0, to_time=9e12):
         for i in range(num_chunks):
             chunk_start_time = chunk_period * 1000 * i + start_time
             next_chunk_start_time = chunk_period * 1000 * (i + 1) + start_time
-            if (chunk_start_time <= to_time and next_chunk_start_time >= from_time):
+            if (chunk_start_time < to_time and next_chunk_start_time > from_time):
                 data_chunk_name = str(i).zfill(len(chunk_pattern) - 4) + chunk_pattern[-4:]
                 data_chunk_url = seg_base_url.replace(chunk_pattern, data_chunk_name)
                 data_chunk = [row['segments.id'], data_chunk_url, chunk_start_time]
@@ -222,10 +225,11 @@ def get_channel_data(all_data, segment_urls, download_function=requests.get, thr
                                   right_on='segments.id', suffixes=('', '_y'))
 
         metadata = metadata[[
-            'dataChunks.url', 'dataChunks.time', 'channelGroups.sampleEncoding',
-            'channelGroups.sampleRate', 'channelGroups.samplesPerRecord',
-            'channelGroups.recordsPerChunk', 'channelGroups.compression', 'channelGroups.signalMin',
-            'channelGroups.signalMax', 'channelGroups.exponent'
+            'dataChunks.url', 'dataChunks.time', 'segments.startTime', 'segments.duration',
+            'channelGroups.sampleEncoding', 'channelGroups.sampleRate',
+            'channelGroups.samplesPerRecord', 'channelGroups.recordsPerChunk',
+            'channelGroups.compression', 'channelGroups.signalMin', 'channelGroups.signalMax',
+            'channelGroups.exponent'
         ]]
         metadata = metadata.drop_duplicates()
         metadata = metadata.dropna(axis=0, how='any', subset=['dataChunks.url'])

--- a/tests/test_data/study1_data_chunk_urls_short.csv
+++ b/tests/test_data/study1_data_chunk_urls_short.csv
@@ -1,0 +1,9 @@
+,segments.id,dataChunks.url,dataChunks.time
+0,study-1-channel-group-1-segment-2-id,https://blah.cloudfront.net/study-1-channel-group-1-segment-2-id_00000000000.dat?Policy=blah&Key-Pair-Id=blah2&Signature=blah4,1526275685734.375
+1,study-1-channel-group-1-segment-2-id,https://blah.cloudfront.net/study-1-channel-group-1-segment-2-id_00000000001.dat?Policy=blah&Key-Pair-Id=blah2&Signature=blah4,1526275695734.375
+2,study-1-channel-group-1-segment-3-id,https://blah.cloudfront.net/study-1-channel-group-1-segment-3-id_00000000000.dat?Policy=blah&Key-Pair-Id=blah2&Signature=blah5,1526275705734.375
+3,study-1-channel-group-1-segment-3-id,https://blah.cloudfront.net/study-1-channel-group-1-segment-3-id_00000000001.dat?Policy=blah&Key-Pair-Id=blah2&Signature=blah5,1526275715734.375
+4,study-1-channel-group-2-segment-2-id,https://blah.cloudfront.net/study-1-channel-group-2-segment-2-id_00000000000.dat?Policy=blah&Key-Pair-Id=blah2&Signature=blah14,1526275685734.375
+5,study-1-channel-group-2-segment-2-id,https://blah.cloudfront.net/study-1-channel-group-2-segment-2-id_00000000001.dat?Policy=blah&Key-Pair-Id=blah2&Signature=blah14,1526275695734.375
+6,study-1-channel-group-2-segment-3-id,https://blah.cloudfront.net/study-1-channel-group-2-segment-3-id_00000000000.dat?Policy=blah&Key-Pair-Id=blah2&Signature=blah15,1526275705734.375
+7,study-1-channel-group-2-segment-3-id,https://blah.cloudfront.net/study-1-channel-group-2-segment-3-id_00000000001.dat?Policy=blah&Key-Pair-Id=blah2&Signature=blah15,1526275715734.375

--- a/tests/test_seerpy.py
+++ b/tests/test_seerpy.py
@@ -454,8 +454,8 @@ class TestGetDocumentsForStudiesDataframe:
         # # this is the "no more data" response for get_documents_for_studies_dataframe()
         with open(TEST_DATA_DIR / "study_documents_empty.json", "r") as f:
             side_effects.append(json.load(f))
-        side_effects.append({'studies':
-                             []})  # this is the "no more data" response for get_studies()
+        # this is the "no more data" response for get_studies()
+        side_effects.append({'studies': []})
 
         gql_client.return_value.execute.side_effect = side_effects
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -30,6 +30,36 @@ class TestCreateDataChunkUrls:
         # check result
         assert result.equals(expected_result)
 
+    def test_success_from_to_on_segment_borders(self):
+        # setup
+        meta_data = pd.read_csv(TEST_DATA_DIR / "study1_metadata_short_durations.csv", index_col=0)
+        segment_urls = pd.read_csv(TEST_DATA_DIR / "segment_urls_3.csv", index_col=0)
+
+        expected_result = pd.read_csv(TEST_DATA_DIR / "study1_data_chunk_urls_short.csv",
+                                      index_col=0)
+
+        # run test
+        result = utils.create_data_chunk_urls(meta_data, segment_urls, from_time=1526275685734.375,
+                                              to_time=1526275725734.375)
+
+        # check result
+        assert result.equals(expected_result)
+
+    def test_success_from_to_within_segments(self):
+        # setup
+        meta_data = pd.read_csv(TEST_DATA_DIR / "study1_metadata_short_durations.csv", index_col=0)
+        segment_urls = pd.read_csv(TEST_DATA_DIR / "segment_urls_3.csv", index_col=0)
+
+        expected_result = pd.read_csv(TEST_DATA_DIR / "study1_data_chunk_urls_short.csv",
+                                      index_col=0)
+
+        # run test
+        result = utils.create_data_chunk_urls(meta_data, segment_urls, from_time=1526275685834.375,
+                                              to_time=1526275725634.375)
+
+        # check result
+        assert result.equals(expected_result)
+
     def test_empty_input(self):
         # setup
         meta_data = pd.read_csv(TEST_DATA_DIR / "empty_metadata.csv", index_col=0)


### PR DESCRIPTION
Data chunks seem to always be 10 seconds long, even the last chunk when less than 10 seconds from the end of a segment - it seems to zero pad out to 10 seconds.

This was leading to issues of duplicate entries when getting data across segment boundaries.
This PR fixes this by only returning data within the segment boundary.

Also fixed an issue where more data chunks than necessary are returned if a request is made on chunk boundaries.

There are no tests for the download function. I looked at adding them but it's more effort than I have to dedicate to it right now.