### PR TITLE
Fix auth logic and broken tests

### DIFF
--- a/seerpy/auth.py
+++ b/seerpy/auth.py
@@ -114,8 +114,20 @@ class SeerAuth(BaseAuth):
             print('Login Successful')
             return
 
-        allowed_attempts = 3
+        allowed_attempts = 4
         for i in range(allowed_attempts):
+            self.login()
+            response = self._verify_login()
+
+            if response == requests.codes.ok:  # pylint: disable=maybe-no-member
+                print('Login Successful')
+                return
+
+            if i >= allowed_attempts - 1:
+                print('Login failed. please check your username and password or go to',
+                      'app.seermedical.com to reset your password')
+                raise InterruptedError('Authentication Failed')
+
             if response == 401:
                 print('\nLogin error, please re-enter your email and password: \n')
                 self.cookie = None
@@ -125,17 +137,6 @@ class SeerAuth(BaseAuth):
                 sleep_time = 5 + 5 * i + 11 * i**2 + random.uniform(0, 5)
                 print(f'\nLogin failed, retrying in {sleep_time:.0f} seconds...')
                 time.sleep(sleep_time)
-
-            self.login()
-            response = self._verify_login()
-
-            if response == requests.codes.ok:  # pylint: disable=maybe-no-member
-                print('Login Successful')
-                return
-
-        print('Login failed. please check your username and password or go to',
-              'app.seermedical.com to reset your password')
-        raise InterruptedError('Authentication Failed')
 
     def _verify_login(self):
         """


### PR DESCRIPTION
Fix an error to the auth logic introduced in my last PR, whereby the `_attempt_login()` `for` loop would be exited after 3 failed attempts, before the `InterruptedError` could be raised as intended. This restores all tests to passing and (hopefully?) makes the loop logic a little easier to follow.

Also:
- Sleep for a few seconds after the first non-401 failed login attempt; don't retry the first time instantly
- Standardise on using `response == requests.codes.ok` in all places, not that and `response == 200`
- Standardise on using `return` after successful login, not that and `break`
- Change f-string formatting from `{sleep_time:d}` -> `{sleep_time:.0f}`, as the former doesn't work with floats