### PR TITLE
Only log in once, if needed, within SeerAuth

### DIFF
--- a/seerpy/auth.py
+++ b/seerpy/auth.py
@@ -155,7 +155,7 @@ class SeerAuth(BaseAuth):
         json_response = response.json()
         if not json_response or not json_response['session'] == "active":
             print("api verify call did not return an active session")
-            return response.status_code
+            return 440
 
         self._write_cookie()
         return response.status_code

--- a/seerpy/seerpy.py
+++ b/seerpy/seerpy.py
@@ -77,7 +77,6 @@ class SeerConnect:  # pylint: disable=too-many-public-methods
         else:
             self.seer_auth = auth
 
-        self.seer_auth.login()
         self.create_client()
 
         self.last_query_time = time.time()


### PR DESCRIPTION
Resolve two small problems with authentication:

1. PR #65 introduced a redundant second call to `SeerAuth.login()`, which gets made in the constructor of `SeerConnect`. Have discussed this with Will and confirmed it was unintentionally introduced and is not needed. It was responsible for seeing e.g.:
```
api verify call did not return an active session
login status_code 200
Login Successful
login status_code 200  # Caused by second unnecessary login() call
```

2. PR #86 changed `SeerAuth._verify_login()` to return the actual status code of the request rather than a hard-coded 401, so that password would only be cleared for 401 errors. However when a cookie has expired, the request returns a 200. This makes `_attempt_login()` return without calling `login()` to get a fresh cookie. Since `login()` is then called from `SeerConnect`, the logical error is being masked and allowing all tests to pass. But it's not robust.

As such:
1. Remove the extra call to `SeerAuth.login()`
2. Have `_verify_login()` return a [440 code](https://en.wikipedia.org/wiki/List_of_HTTP_status_codes#440) for expired cookies, not 200. NB this is not a standard HTTP code, but as discussed in [this thread](https://stackoverflow.com/a/22484262/8822495) there isn't really a good option from the standard codes. 403 is probably the best out of the standard codes - I'm happy to change this to anything else; it just can't be 200 or 401.