### PR TITLE
Add ability to download timestamped Sense data

### DIFF
--- a/seerpy/graphql.py
+++ b/seerpy/graphql.py
@@ -104,6 +104,7 @@ def get_study_with_data_query_string(study_id):
                     signalMax
                     units
                     exponent
+                    timestamped
                     segments (fromTime: 1.0, toTime: 9000000000000) {
                         id
                         startTime
@@ -859,7 +860,7 @@ def get_remove_users_from_user_cohort_mutation_string(user_cohort_id, user_ids):
 
 
 def get_add_user_timezone_mutation_string(user_id, timezone):
-    return """ 
+    return """
         mutation  {
             editUser(
                 id: "%s",

--- a/seerpy/utils.py
+++ b/seerpy/utils.py
@@ -64,9 +64,14 @@ def download_channel_data(data_q, download_function):
         column_names = channel_names
 
         if meta_data['channelGroups.timestamped']:
+            # timestamped data is not stored in records as EDF data is
+            # it is just a sequence of (ts, ch1, ch2, ..., chN), (ts, ch1, ch2, ..., chN), ...
+            # the timestamp is milliseconds relative to chunk start
             column_names = ['time'] + channel_names
             data = data.reshape(-1, len(column_names))
         else:
+            # EDF data is in the format [record 1: (ch1 sample1, ch1 sample2, ..., ch2 sampleN),
+            # (ch2 sample1, ch2 sample2, ..., ch2 sampleN), ...][record2: ...], ..., [recordN: ...]
             data = data.reshape(-1, len(channel_names),
                                 int(meta_data['channelGroups.samplesPerRecord']))
             data = np.transpose(data, (0, 2, 1))

--- a/seerpy/utils.py
+++ b/seerpy/utils.py
@@ -249,7 +249,7 @@ def get_channel_data(all_data, segment_urls, download_function=requests.get, thr
             'channelGroups.sampleEncoding', 'channelGroups.sampleRate',
             'channelGroups.samplesPerRecord', 'channelGroups.recordsPerChunk',
             'channelGroups.compression', 'channelGroups.signalMin', 'channelGroups.signalMax',
-            'channelGroups.exponent'
+            'channelGroups.exponent', 'channelGroups.timestamped'
         ]]
         metadata = metadata.drop_duplicates()
         metadata = metadata.dropna(axis=0, how='any', subset=['dataChunks.url'])


### PR DESCRIPTION
Data from the sense is stored in a different format to that which comes from the Siesta.
This PR adds the "timestamped" flag from the channel group, which indicates whether the data is in this format or the existing format, and changes the utils.download_channel_data function to cater for the new format as well as the existing one.

Again, there is no unit test for this function as yet, but I have tested it on both Sense and Siesta data.