### PR TITLE
Add channelGroupType to study query

### DIFF
--- a/seerpy/graphql.py
+++ b/seerpy/graphql.py
@@ -105,6 +105,9 @@ def get_study_with_data_query_string(study_id):
                     units
                     exponent
                     timestamped
+                    channelGroupType {
+                        id
+                    }
                     segments (fromTime: 1.0, toTime: 9000000000000) {
                         id
                         startTime


### PR DESCRIPTION
This is required to be able to discriminate between types of channel groups without relying on the type on the channels.