### PR TITLE
Small bug fix in get_labels_dataframe() when no labels exist

### DIFF
--- a/seerpy/seerpy.py
+++ b/seerpy/seerpy.py
@@ -749,8 +749,8 @@ class SeerConnect:  # pylint: disable=too-many-public-methods
             Details of all matching labels
         """
         label_results = self.get_labels(study_id, label_group_id, from_time, to_time, limit, offset)
-        if label_results is None:
-            return label_results
+        if not label_results:
+            return pd.DataFrame()
         label_group = json_normalize(label_results).sort_index(axis=1)
         labels = self.pandas_flatten(label_group, 'labelGroup.', 'labels')
         tags = self.pandas_flatten(labels, 'labels.', 'tags')


### PR DESCRIPTION
In `get_labels_dataframe()` check if labels, instead of checking if labels is `None` as empty labels return `[]`.