### PR TITLE
Add edit label group mutation

### DIFF
--- a/seerpy/graphql.py
+++ b/seerpy/graphql.py
@@ -343,7 +343,7 @@ EDIT_STUDY_LABEL_GROUP = """
     mutation editStudyLabelGroup($group_id: String!,
                                  $name: String,
                                  $description: String) {
-        editStudyLabelGroup(id: $id,
+        editStudyLabelGroup(id: $group_id,
                             name: $name,
                             description: $description) {
             id

--- a/seerpy/graphql.py
+++ b/seerpy/graphql.py
@@ -338,6 +338,18 @@ def get_remove_label_group_mutation_string(group_id):
         }""" % (group_id)
 
 
+EDIT_STUDY_LABEL_GROUP = """
+    mutation editStudyLabelGroup($id: String!,
+                                 $name: String,
+                                 $description: String) {
+        editStudyLabelGroup(id: $id,
+                            name: $name,
+                            description: $description) {
+            id
+        }
+    }"""
+
+
 def get_viewed_times_query_string(study_id, limit, offset):
     return """
         query {
@@ -441,7 +453,7 @@ def get_diary_labels_query_string():
         query getDiaryLabels(
             $id: String!,
             $value: String!,
-            $limit: PaginationAmount, 
+            $limit: PaginationAmount,
             $offset: Int,
             $from_time: Float!,
             $to_time: Float!,

--- a/seerpy/graphql.py
+++ b/seerpy/graphql.py
@@ -203,6 +203,7 @@ def get_label_groups_for_study_ids_paged_query_string(study_ids):
                 labelGroups {{{{
                     id
                     name
+                    description
                     labelType
                     numberOfLabels
                 }}}}

--- a/seerpy/graphql.py
+++ b/seerpy/graphql.py
@@ -340,7 +340,7 @@ def get_remove_label_group_mutation_string(group_id):
 
 
 EDIT_STUDY_LABEL_GROUP = """
-    mutation editStudyLabelGroup($id: String!,
+    mutation editStudyLabelGroup($group_id: String!,
                                  $name: String,
                                  $description: String) {
         editStudyLabelGroup(id: $id,

--- a/seerpy/seerpy.py
+++ b/seerpy/seerpy.py
@@ -317,7 +317,7 @@ class SeerConnect:  # pylint: disable=too-many-public-methods
 
     def edit_study_label_group(self, group_id, name, description):
         """
-        Edit a label group.
+        Edit a study label group.
 
         Parameters
         ----------

--- a/seerpy/seerpy.py
+++ b/seerpy/seerpy.py
@@ -878,11 +878,13 @@ class SeerConnect:  # pylint: disable=too-many-public-methods
             Columns with details on name, id, type, and number of labels, as
             well as study ID and name
         """
+        # TODO: can we use json_normalize or pandas_flatten for this?
         label_groups = []
         for study in self.get_label_groups_for_studies(study_ids, limit):
             for label_group in study['labelGroups']:
                 label_group['labelGroup.id'] = label_group.pop('id')
                 label_group['labelGroup.name'] = label_group.pop('name')
+                label_group['labelGroup.description'] = label_group.pop('description')
                 label_group['labelGroup.labelType'] = label_group.pop('labelType')
                 label_group['labelGroup.numberOfLabels'] = label_group.pop('numberOfLabels')
                 label_group['id'] = study['id']

--- a/seerpy/seerpy.py
+++ b/seerpy/seerpy.py
@@ -315,6 +315,31 @@ class SeerConnect:  # pylint: disable=too-many-public-methods
         query_string = graphql.get_remove_label_group_mutation_string(group_id)
         return self.execute_query(query_string)
 
+    def edit_label_group(self, group_id, name, description):
+        """
+        Edit a label group.
+
+        Parameters
+        ----------
+        group_id : str
+            Label group ID to edit
+        name : str
+            Name of the label group
+        description : str
+            Free text description of the label group
+
+        Returns
+        -------
+        label_group_id : str
+            ID of the edited label group
+        """
+        variable_values = {
+            "id": group_id,
+            "name": name,
+            "description": description
+        }
+        return self.execute_query(graphql.EDIT_STUDY_LABEL_GROUP, variable_values=variable_values)
+
     def add_labels_batched(self, label_group_id, labels, batch_size=500):
         """
         Add labels to label group in batches.

--- a/seerpy/seerpy.py
+++ b/seerpy/seerpy.py
@@ -315,7 +315,7 @@ class SeerConnect:  # pylint: disable=too-many-public-methods
         query_string = graphql.get_remove_label_group_mutation_string(group_id)
         return self.execute_query(query_string)
 
-    def edit_label_group(self, group_id, name, description):
+    def edit_study_label_group(self, group_id, name, description):
         """
         Edit a label group.
 

--- a/seerpy/seerpy.py
+++ b/seerpy/seerpy.py
@@ -334,7 +334,7 @@ class SeerConnect:  # pylint: disable=too-many-public-methods
             ID of the edited label group
         """
         variable_values = {
-            "id": group_id,
+            "group_id": group_id,
             "name": name,
             "description": description
         }
@@ -1950,4 +1950,3 @@ class SeerConnect:  # pylint: disable=too-many-public-methods
         query_string = graphql.get_remove_users_from_user_cohort_mutation_string(
             user_cohort_id, user_ids)
         return self.execute_query(query_string)
-

--- a/tests/test_graphql.py
+++ b/tests/test_graphql.py
@@ -3,7 +3,7 @@ from gql import gql
 import seerpy.graphql as graphql
 
 
-def test_graphql_query_string():
+def test_graphql_query_strings():
     """Ensure query strings parse correctly."""
     gql(graphql.get_add_labels_mutation_string())
     gql(graphql.get_tag_id_query_string())

--- a/tests/test_graphql.py
+++ b/tests/test_graphql.py
@@ -1,0 +1,16 @@
+from gql import gql
+
+import seerpy.graphql as graphql
+
+
+def test_graphql_query_string():
+    """Ensure query strings parse correctly."""
+    gql(graphql.get_add_labels_mutation_string())
+    gql(graphql.get_tag_id_query_string())
+    gql(graphql.EDIT_STUDY_LABEL_GROUP)
+    gql(graphql.get_organisations_query_string())
+    gql(graphql.get_patients_query_string())
+    gql(graphql.get_diary_labels_query_string())
+    gql(graphql.get_diary_medication_alerts_query_string())
+    gql(graphql.get_diary_medication_alert_windows_query_string())
+    gql(graphql.get_diary_medication_compliance_query_string())


### PR DESCRIPTION
Adds a new mutation to edit a study label group (name, description).
Adds description field to get label groups query (so you can set the original in edit label group).
Adds a test file to check parsing of graphql queries.