### PR TITLE
Enable the use of datachunk urls (including s3 urls) in get_channel_data

### DIFF
--- a/seerpy/seerpy.py
+++ b/seerpy/seerpy.py
@@ -1489,16 +1489,12 @@ class SeerConnect:  # pylint: disable=too-many-public-methods
         >>> ecg_metadata_df = metadata_df[metadata_df['channelGroups.name'] == 'ECG']
         >>> ecg_data_df = get_channel_data(ecg_metadata_df)
         """
-        data_chunk_urls = segment_urls
-        if data_chunk_urls is None:
-            data_chunk_urls = self.get_data_chunk_urls(all_data, s3_urls=direct_s3_access,
-                                                       from_time=from_time, to_time=to_time)
-        elif 'baseDataChunkUrl' in data_chunk_urls.columns:
-            data_chunk_urls = utils.create_data_chunk_urls(all_data, data_chunk_urls, from_time,
-                                                           to_time)
+        if segment_urls is None:
+            segment_urls = self.get_data_chunk_urls(all_data, s3_urls=direct_s3_access,
+                                                    from_time=from_time, to_time=to_time)
 
-        return utils.get_channel_data(all_data, data_chunk_urls, download_function, threads,
-                                      from_time, to_time)
+        return utils.get_channel_data(all_data, segment_urls, download_function, threads, from_time,
+                                      to_time)
 
     def get_all_bookings(self, organisation_id, start_time, end_time):
         """

--- a/seerpy/seerpy.py
+++ b/seerpy/seerpy.py
@@ -1447,7 +1447,7 @@ class SeerConnect:  # pylint: disable=too-many-public-methods
 
     # pylint:disable=too-many-locals,too-many-arguments
     def get_channel_data(self, all_data, segment_urls=None, download_function=requests.get,
-                         threads=None, from_time=0, to_time=9e12, direct_s3_access=True):
+                         threads=None, from_time=0, to_time=9e12, s3_urls=True):
         """
         Download raw data for all channel groups and segments listed in a given metadata DataFrame
         and return as a new DataFrame.
@@ -1470,9 +1470,9 @@ class SeerConnect:  # pylint: disable=too-many-public-methods
             Timestamp in msec - only retrieve data from this point onward
         to_time : float, optional
             Timestamp in msec - only retrieve data up until this point
-        direct_s3_access : bool, optional
+        s3_urls : bool, optional
             Note: this only has an effect if segment_urls is None. If True (default), download
-            direct from S3 (otherwise download via Cloudfront). S3 should be preferred when running
+            using S3 urls (otherwise download via Cloudfront). S3 should be preferred when running
             in the same AWS region as the data is stored.
 
         Returns
@@ -1490,8 +1490,8 @@ class SeerConnect:  # pylint: disable=too-many-public-methods
         >>> ecg_data_df = get_channel_data(ecg_metadata_df)
         """
         if segment_urls is None:
-            segment_urls = self.get_data_chunk_urls(all_data, s3_urls=direct_s3_access,
-                                                    from_time=from_time, to_time=to_time)
+            segment_urls = self.get_data_chunk_urls(all_data, s3_urls=s3_urls, from_time=from_time,
+                                                    to_time=to_time)
 
         return utils.get_channel_data(all_data, segment_urls, download_function, threads, from_time,
                                       to_time)

--- a/seerpy/seerpy.py
+++ b/seerpy/seerpy.py
@@ -1487,6 +1487,52 @@ class SeerConnect:  # pylint: disable=too-many-public-methods
         return utils.get_channel_data(all_data, segment_urls, download_function, threads, from_time,
                                       to_time)
 
+    # pylint:disable=too-many-locals,too-many-arguments
+    def get_channel_data_new(self, study_metadata, data_chunk_urls=None,
+                             download_function=requests.get, threads=None, from_time=0,
+                             to_time=9e12):
+        """
+        Download raw data for all channel groups and segments listed in a given metadata DataFrame
+        and return as a new DataFrame.
+
+        Parameters
+        ----------
+        study_metadata : pd.DataFrame
+            Study metadata, as returned by `get_all_study_metadata_dataframe_by_*()`
+        data_chunk_urls : pd.DataFrame, optional
+            DataFrame with columns ['segments.id', 'chunkIndex', 'chunk_start', 'chunk_end',
+            'chunk_url']. If None or empty, these will be retrieved for each segment in
+            `study_metadata`.
+        download_function : callable, optional
+            The function used to download the channel data. Defaults to requests.get
+        threads : int, optional
+            Number of threads to use. If > 1 will use multiprocessing. If None (default), will use
+            1 on Windows and 5 on Linux/MacOS.
+        from_time : int, optional
+            Timestamp in msec - only retrieve data from this point onward
+        to_time : int, optional
+            Timestamp in msec - only retrieve data up until this point
+
+        Returns
+        -------
+        data_df : pd.DataFrame
+            DataFrame with 'time', 'id', 'channelGroups.id' and 'segments.id' columns, as well as a
+            column for each data channel, e.g. each EEG electrode.
+
+        Example
+        -------
+        Get all ECG data for a study of patient "Jane Doe":
+        >>> study_id = get_study_ids(search_term='Jane Doe')[0]['id']
+        >>> metadata_df = get_all_study_metadata_dataframe_by_ids(study_id)
+        >>> ecg_metadata_df = metadata_df[metadata_df['channelGroups.name'] == 'ECG']
+        >>> ecg_data_df = get_channel_data(ecg_metadata_df)
+        """
+        if not data_chunk_urls:
+            data_chunk_urls = self.get_data_chunk_urls(study_metadata)
+
+        return utils.get_channel_data_new(study_metadata, data_chunk_urls, download_function,
+                                          threads, from_time, to_time)
+
     def get_all_bookings(self, organisation_id, start_time, end_time):
         """
         Get all bookings for any studies that are active at any point between

--- a/seerpy/seerpy.py
+++ b/seerpy/seerpy.py
@@ -670,9 +670,9 @@ class SeerConnect:  # pylint: disable=too-many-public-methods
         s3_urls : bool, optional
             If True (default), return download URLs for S3 (otherwise return URLs for Cloudfront).
             S3 should be preferred when running in the same AWS region as the data is stored.
-        from_time : int, optional
+        from_time : float, optional
             Timestamp in msec - only retrieve data from this point onward
-        to_time : int, optional
+        to_time : float, optional
             Timestamp in msec - only retrieve data up until this point
         limit : int, options
             Batch size for repeated API calls
@@ -1466,9 +1466,9 @@ class SeerConnect:  # pylint: disable=too-many-public-methods
         threads : int, optional
             Number of threads to use. If > 1 will use multiprocessing. If None (default), will use
             1 on Windows and 5 on Linux/MacOS.
-        from_time : int, optional
+        from_time : float, optional
             Timestamp in msec - only retrieve data from this point onward
-        to_time : int, optional
+        to_time : float, optional
             Timestamp in msec - only retrieve data up until this point
         direct_s3_access : bool, optional
             Note: this only has an effect if segment_urls is None. If True (default), download
@@ -1491,7 +1491,8 @@ class SeerConnect:  # pylint: disable=too-many-public-methods
         """
         data_chunk_urls = segment_urls
         if data_chunk_urls is None:
-            data_chunk_urls = self.get_data_chunk_urls(all_data, s3_urls=direct_s3_access)
+            data_chunk_urls = self.get_data_chunk_urls(all_data, s3_urls=direct_s3_access,
+                                                       from_time=from_time, to_time=to_time)
         elif 'baseDataChunkUrl' in data_chunk_urls.columns:
             data_chunk_urls = utils.create_data_chunk_urls(all_data, data_chunk_urls, from_time,
                                                            to_time)

--- a/seerpy/utils.py
+++ b/seerpy/utils.py
@@ -164,9 +164,9 @@ def create_data_chunk_urls(metadata, segment_urls, from_time=0, to_time=9e12):
     segment_urls : pd.DataFrame
         DataFrame with columns 'segments.id', and 'baseDataChunkUrl', as returned
         by seerpy.get_segment_urls()
-    from_time : int, optional
-        Only include data chunks that start after this time
-    to_time : int, optional
+    from_time : float, optional
+        Only include data chunks that end after this time
+    to_time : float, optional
         Only include data chunks that start before this time
 
     Returns
@@ -223,9 +223,9 @@ def get_channel_data(study_metadata, data_chunk_urls, download_function=requests
     threads : int, optional
         Number of threads to use. If > 1 then will use multiprocessing. If None (default), it will
         use 1 on Windows and 5 on Linux/MacOS
-    from_time : int, optional
+    from_time : float, optional
         Timestamp in msec - only retrieve data from this point onward
-    to_time : int, optional
+    to_time : float, optional
         Timestamp in msec - only retrieve data up until this point
 
     Returns

--- a/seerpy/utils.py
+++ b/seerpy/utils.py
@@ -206,7 +206,7 @@ def create_data_chunk_urls(metadata, segment_urls, from_time=0, to_time=9e12):
 
 
 # pylint:disable=too-many-locals,too-many-arguments
-def get_channel_data(study_metadata, data_chunk_urls, download_function=requests.get, threads=None,
+def get_channel_data(study_metadata, segment_urls, download_function=requests.get, threads=None,
                      from_time=0, to_time=9e12):
     """
     Download data chunks and stitch together into a single DataFrame.
@@ -215,9 +215,10 @@ def get_channel_data(study_metadata, data_chunk_urls, download_function=requests
     ----------
     study_metadata : pd.DataFrame
         Study metadata as returned by seerpy.get_all_study_metadata_dataframe_by_*()
-    data_chunk_urls : pd.DataFrame
-        DataFrame with columns ['segments.id', 'dataChunks.url', 'dataChunks.time'] as returned by
-        `seerpy.get_data_chunk_urls`
+    segment_urls : pd.DataFrame
+        DataFrame with columns ['segments.id', 'baseDataChunkUrl'] as returned by
+        `seerpy.get_segment_urls`, or with columns ['segments.id', 'dataChunks.time',
+        'dataChunks.url'] as returned by `seerpy.get_data_chunk_urls`.
     download_function : callable
         The function used to download the channel data. Defaults to requests.get
     threads : int, optional
@@ -238,6 +239,11 @@ def get_channel_data(study_metadata, data_chunk_urls, download_function=requests
             threads = 1
         else:
             threads = 5
+
+    data_chunk_urls = segment_urls
+    if 'baseDataChunkUrl' in data_chunk_urls.columns:
+        data_chunk_urls = create_data_chunk_urls(study_metadata, data_chunk_urls, from_time,
+                                                 to_time)
 
     data_q = []
 

--- a/seerpy/utils.py
+++ b/seerpy/utils.py
@@ -206,98 +206,8 @@ def create_data_chunk_urls(metadata, segment_urls, from_time=0, to_time=9e12):
 
 
 # pylint:disable=too-many-locals,too-many-arguments
-def get_channel_data(all_data, segment_urls, download_function=requests.get, threads=None,
+def get_channel_data(study_metadata, data_chunk_urls, download_function=requests.get, threads=None,
                      from_time=0, to_time=9e12):
-    """
-    Download data chunks and stitch together into a single DataFrame.
-
-    Parameters
-    ----------
-    all_data : pd.DataFrame
-        Study metadata as returned by seerpy.get_all_study_metadata_dataframe_by_*()
-    segment_urls : pd.DataFrame
-        DataFrame with columns ['segments.id', 'baseDataChunkUrl'] as returned
-        by seerpy.get_segment_urls()
-    download_function : callable
-        The function used to download the channel data. Defaults to requests.get
-    threads : int, optional
-        Number of threads to use. If > 1 then will use multiprocessing. If None
-        (default), it will use 1 on Windows and 5 on Linux/MacOS
-    from_time : int, optional
-        Timestamp in msec - only retrieve data from this point onward
-    to_time : int, optional
-        Timestamp in msec - only retrieve data up until this point
-
-    Returns
-    -------
-    data_df : pd.DataFrame
-        DataFrame containing study ID, channel group IDs, semgment IDs, time, and raw data
-    """
-    if threads is None:
-        if os.name == 'nt':
-            threads = 1
-        else:
-            threads = 5
-
-    segment_ids = all_data['segments.id'].drop_duplicates().tolist()
-
-    data_q = []
-    data_list = []
-
-    for segment_id in segment_ids:
-        metadata = all_data[all_data['segments.id'].values == segment_id]
-        actual_channel_names = get_channel_names_or_ids(metadata)
-        metadata = metadata.drop_duplicates('segments.id')
-
-        study_id = metadata['id'].iloc[0]
-        channel_groups_id = metadata['channelGroups.id'].iloc[0]
-
-        data_chunks = create_data_chunk_urls(metadata, segment_urls, from_time=from_time,
-                                             to_time=to_time)
-        metadata = metadata.merge(data_chunks, how='left', left_on='segments.id',
-                                  right_on='segments.id', suffixes=('', '_y'))
-
-        metadata = metadata[[
-            'dataChunks.url', 'dataChunks.time', 'segments.startTime', 'segments.duration',
-            'channelGroups.sampleEncoding', 'channelGroups.sampleRate',
-            'channelGroups.samplesPerRecord', 'channelGroups.recordsPerChunk',
-            'channelGroups.compression', 'channelGroups.signalMin', 'channelGroups.signalMax',
-            'channelGroups.exponent', 'channelGroups.timestamped'
-        ]]
-        metadata = metadata.drop_duplicates()
-        metadata = metadata.dropna(axis=0, how='any', subset=['dataChunks.url'])
-        for i in range(len(metadata.index)):
-            data_q.append(
-                [metadata.iloc[i], study_id, channel_groups_id, segment_id, actual_channel_names])
-
-    download_function = functools.partial(download_channel_data,
-                                          download_function=download_function)
-    if data_q:
-        if threads > 1:
-            pool = Pool(processes=min(threads, len(data_q) + 1))
-            data_list = list(pool.map(download_function, data_q))
-            pool.close()
-            pool.join()
-        else:
-            data_list = [download_function(data_q_item) for data_q_item in data_q]
-
-    if data_list:
-        # sort=False to silence deprecation warning. This comes into play when we are processing
-        # segments across multiple channel groups which have different channels.
-        data = pd.concat(data_list, sort=False)
-        data = data.loc[(data['time'] >= from_time) & (data['time'] < to_time)]
-        data = data.sort_values(['id', 'channelGroups.id', 'time'], axis=0, ascending=True,
-                                na_position='last')
-        data = data.reset_index(drop=True)
-    else:
-        data = None
-
-    return data
-
-
-# pylint:disable=too-many-locals,too-many-arguments
-def get_channel_data_new(study_metadata, data_chunk_urls, download_function=requests.get,
-                         threads=None, from_time=0, to_time=9e12):
     """
     Download data chunks and stitch together into a single DataFrame.
 
@@ -305,14 +215,14 @@ def get_channel_data_new(study_metadata, data_chunk_urls, download_function=requ
     ----------
     study_metadata : pd.DataFrame
         Study metadata as returned by seerpy.get_all_study_metadata_dataframe_by_*()
-    data_chunk_urls : pd.DataFrame, optional
-        DataFrame with columns ['segments.id', 'chunkIndex', 'chunk_start', 'chunk_end',
-        'chunk_url'].
+    data_chunk_urls : pd.DataFrame
+        DataFrame with columns ['segments.id', 'dataChunks.url', 'dataChunks.time'] as returned by
+        `seerpy.get_data_chunk_urls`
     download_function : callable
         The function used to download the channel data. Defaults to requests.get
     threads : int, optional
-        Number of threads to use. If > 1 then will use multiprocessing. If None
-        (default), it will use 1 on Windows and 5 on Linux/MacOS
+        Number of threads to use. If > 1 then will use multiprocessing. If None (default), it will
+        use 1 on Windows and 5 on Linux/MacOS
     from_time : int, optional
         Timestamp in msec - only retrieve data from this point onward
     to_time : int, optional
@@ -329,14 +239,9 @@ def get_channel_data_new(study_metadata, data_chunk_urls, download_function=requ
         else:
             threads = 5
 
-    segment_ids = study_metadata['segments.id'].drop_duplicates().tolist()
-
-    data_chunk_urls.rename(columns={'chunk_url': 'dataChunks.url',
-                                    'chunk_start': 'dataChunks.time'})
-
     data_q = []
-    data_list = []
 
+    segment_ids = study_metadata['segments.id'].drop_duplicates().tolist()
     for segment_id in segment_ids:
         metadata = study_metadata[study_metadata['segments.id'].values == segment_id]
         actual_channel_names = get_channel_names_or_ids(metadata)
@@ -363,6 +268,7 @@ def get_channel_data_new(study_metadata, data_chunk_urls, download_function=requ
 
     download_function = functools.partial(download_channel_data,
                                           download_function=download_function)
+    data_list = []
     if data_q:
         if threads > 1:
             pool = Pool(processes=min(threads, len(data_q) + 1))


### PR DESCRIPTION
Changes get_channel_data to allow the use of data chunk urls (including s3 urls) as well as the existing segment urls.
Also fixes some errors in get_data_chunk_urls and renames the data chunk columns to mirror the existing datachunk columns from utils.create_data_chunk_urls. (I'm pretty sure no-one was previously using seerpy.get_data_chunk_urls or they would have noticed it's problems).

The default if you call get_channel_data with default parameters will now be to use s3 to download instead of cloudfront, which is cheaper for us as long as the retrieving code is running in the same aws region as the data, and otherwise is equivalent.