### PR TITLE
Use parquet instead of JSON in MSG downloader example script

### DIFF
--- a/Examples/downloader/downloader.py
+++ b/Examples/downloader/downloader.py
@@ -43,7 +43,7 @@ class DataDownloader:
         for index, segment_id in enumerate(tqdm(segment_ids)):
             segment_metadata = channel_metadata[channel_metadata['segments.id'] == segment_id]
             segment_file = join(
-                folder_out, f'{self.study_name}_{channel_group}_{channel}_segment_{index}.json')
+                folder_out, f'{self.study_name}_{channel_group}_{channel}_segment_{index}.parquet')
             if isfile(segment_file):
                 continue
             try:
@@ -57,24 +57,10 @@ class DataDownloader:
             segment_row = segment_metadata.iloc[0, :]
 
             data = {}
-            data['id'] = segment_row['id']
-            data['channel_group'] = {}
-            data['channel_group']['channel_group_id'] = segment_row['channelGroups.id']
-            data['channel_group']['channel_group_name'] = channel_group
-            data['channel_group']['sample_rate'] = int(segment_row['channelGroups.sampleRate'])
-            data['channel_group']['units'] = segment_row['channelGroups.units']
-            data['channel_group']['exponent'] = int(segment_row['channelGroups.exponent'])
-            data['channel_group']['signal_min'] = int(segment_row['channelGroups.signalMin'])
-            data['channel_group']['signal_max'] = int(segment_row['channelGroups.signalMax'])
-            data['channel_group']['channel'] = {}
-            data['channel_group']['channel']['channel_id'] = segment_row['channels.id']
-            data['channel_group']['channel']['channel_name'] = channel
-            data['channel_group']['channel']['segment'] = {}
-            data['channel_group']['channel']['segment']['segment_index'] = index
-            data['channel_group']['channel']['segment']['segment_id'] = segment_row['segments.id']
-            data['channel_group']['channel']['segment']
-            data['channel_group']['channel']['segment']['time'] = segment_data['time'].tolist()
-            data['channel_group']['channel']['segment']['data'] = segment_data[channel].tolist()
+            data = pd.DataFrame({
+                'time': segment_data['time'].tolist(),
+                'data': segment_data[channel].tolist()
+            })
 
             yield data, segment_file
 
@@ -104,7 +90,7 @@ class DataDownloader:
                                                                     channel, channel_metadata,
                                                                     segment_ids):
                 # Save segment data to JSON
-                write_json(segment_file, segment_data)
+                segment_data.to_parquet(segment_file)
         print('Done.')
 
     def download_label_data(self):

--- a/Examples/downloader/utils.py
+++ b/Examples/downloader/utils.py
@@ -8,12 +8,14 @@ def write_json(file_path, obj):
         json.dump(obj, f, indent=4)
         f.close
 
+
 def read_json(file_path):
     """Reads a JSON file to a dictionary object."""
     with open(file_path, 'r') as f:
         obj = json.load(f)
         f.close()
-    return obj 
+    return obj
+
 
 def add_to_csv(file_path, content):
     """Reads a CSV file, appends DataFrame content, and

--- a/Examples/msg_data_downloader.py
+++ b/Examples/msg_data_downloader.py
@@ -6,9 +6,8 @@ import argparse
 from os import mkdir
 from os.path import dirname, isdir, isfile, join
 from seerpy import SeerConnect
-from urllib3.exceptions import ReadTimeoutError
-
 from downloader.downloader import DataDownloader
+from urllib3.exceptions import ReadTimeoutError
 from downloader.utils import read_json, write_json
 
 
@@ -76,9 +75,8 @@ def run(client, path_out):
 
         # If user reaches 5 attempts, break and request user to return later
         if attempts == 5:
-            print(
-                "ReadTimeoutError! Number of tries exceeded. Please re-run this script at a later time."
-            )
+            print("ReadTimeoutError! Number of tries exceeded. Please re-run \
+                this script at a later time.")
             break
 
     return


### PR DESCRIPTION
Use parquet instead of JSON in MSG downloader example script. 

Most changes are formatting.