### PR TITLE
Add timezone to meds compliance query

### DIFF
--- a/seerpy/graphql.py
+++ b/seerpy/graphql.py
@@ -544,12 +544,13 @@ GET_DIARY_MEDICATION_ALERT_WINDOWS = """
 GET_DIARY_MEDICATION_COMPLIANCE = """
     query getMedicationCompliance($patient_id: String!,
                                   $from_time: Float!,
-                                  $to_time: Float!) {
+                                  $to_time: Float!,
+                                  $timezone: String) {
         patient (id: $patient_id) {
             id
             diary {
                 id
-                medicationCompliance (range: { from: $from_time, to: $to_time }) {
+                medicationCompliance (range: { from: $from_time, to: $to_time }, timezone: $timezone) {
                     label
                     status
                     date

--- a/seerpy/seerpy.py
+++ b/seerpy/seerpy.py
@@ -1309,7 +1309,8 @@ class SeerConnect:  # pylint: disable=too-many-public-methods
             Timestamp in msec - only retrieve data up until this point. The default value of 0 means
             up until this point in time for this query
         timezone: string, optional
-            The timezone to reteriwece medication compliance for
+            The timezone name to retrieve medication compliance for,
+            (e.g. "Australia/Melbourne")
 
         Returns
         -------

--- a/seerpy/seerpy.py
+++ b/seerpy/seerpy.py
@@ -1294,7 +1294,8 @@ class SeerConnect:  # pylint: disable=too-many-public-methods
                                       variable_values=variable_values)
         return response['patient']['diary']['alerts']
 
-    def get_diary_medication_compliance(self, patient_id, from_time=0, to_time=0):
+    def get_diary_medication_compliance(self, patient_id, from_time=0, to_time=0,
+                                        timezone_string=None):
         """
         Gets all medication compliance records for a given patient.
 
@@ -1307,6 +1308,8 @@ class SeerConnect:  # pylint: disable=too-many-public-methods
         to_time : int, optional
             Timestamp in msec - only retrieve data up until this point. The default value of 0 means
             up until this point in time for this query
+        timezone: string, optional
+            The timezone to reteriwece medication compliance for
 
         Returns
         -------
@@ -1315,6 +1318,10 @@ class SeerConnect:  # pylint: disable=too-many-public-methods
             'diary' key, which indexes a dictionary with a 'medicationCompliance' key.
         """
         variable_values = {'patient_id': patient_id, 'from_time': from_time, 'to_time': to_time}
+
+        if timezone_string is not None:
+            variable_values['timezone'] = timezone_string
+
         return self.execute_query(graphql.GET_DIARY_MEDICATION_COMPLIANCE,
                                   variable_values=variable_values)
 


### PR DESCRIPTION
The medication compliance API returns unexpected results if a timezone is not supplied. This PR adds an optional timezone argument to the medication compliance query.