### PR TITLE
Add script to download studies in Examples folder

### DIFF
--- a/Examples/download_studies.py
+++ b/Examples/download_studies.py
@@ -1,0 +1,79 @@
+# -*- coding: utf-8 -*-
+import sys
+import time
+import argparse
+
+from os import mkdir
+from os.path import dirname, isdir, isfile, join
+from urllib3.exceptions import ReadTimeoutError
+from downloader.utils import read_json, write_json
+from seerpy import SeerConnect
+from downloader.downloader import DataDownloader
+
+
+def get_download_status_file(client):
+    """Retrieves JSON of download status for all study IDs."""
+    studies_file = join(dirname(__file__), 'studies.json')
+    if not isfile(studies_file):
+        status = {
+            study_id: 0
+            for study_id in client.get_study_ids()
+        }
+        write_json(studies_file, status)
+    return studies_file
+
+
+def run(client, path_out, channel_group_to_download):
+    """Downloads all data available on Seer's public API."""
+    if path_out:
+        if not isdir(path_out):
+            print('Please specify a path that exists.')
+            return
+        output_dir = join(path_out, 'data')
+    else:
+        output_dir = join(dirname(__file__), 'data')
+    if not isdir(output_dir):
+        mkdir(output_dir)
+
+    download_status_file = get_download_status_file(client)
+    download_status = read_json(download_status_file)
+    study_ids = [study_id for study_id in download_status if download_status[study_id] == 0]
+
+    attempts = 0
+    while True:
+        try:
+            if attempts != 0:
+                time.sleep(3)
+                client = SeerConnect()
+            for study_id in study_ids:
+                downloader = DataDownloader(client, study_id, output_dir)
+                # Download channel data
+                downloader.download_channel_data(channel_group_to_download)
+                download_status[study_id] = 1
+                write_json(download_status_file, download_status)
+            print('Download completed.')
+            return
+
+        except ReadTimeoutError:
+            attempts += 1
+            for i in range(5, 0, -1):
+                sys.stdout.write(f'ReadTimeoutError. Re-trying after a short break... {str(i)}')
+                sys.stdout.flush()
+                time.sleep(1)
+
+        # If user reaches 5 attempts, break and request user to return later
+        if attempts == 5:
+            print("ReadTimeoutError! Number of tries exceeded. Please re-run \
+                this script at a later time.")
+            break
+
+    return
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-o", "--outpath", help="Path for data to be saved (optional).")
+    parser.add_argument("-cg", "--channelgroup", help="Name of channel group to download.")
+    args = parser.parse_args()
+
+    run(SeerConnect(), args.outpath, args.channelgroup)

--- a/Examples/download_studies.py
+++ b/Examples/download_studies.py
@@ -87,5 +87,5 @@ if __name__ == '__main__':
     parser.add_argument("-c", "--channels", nargs="+", help="Name of channels to download (optional).")
     parser.add_argument("-p", "--party_id", help="Party ID for specific organisation to download studies from.")
     args = parser.parse_args()
-    breakpoint()
+ 
     run(SeerConnect(), args.outpath, args.update, args.channelgroups, args.channels, args.party_id)

--- a/Examples/download_studies.py
+++ b/Examples/download_studies.py
@@ -11,19 +11,29 @@ from seerpy import SeerConnect
 from downloader.downloader import DataDownloader
 
 
-def get_download_status_file(client):
+def get_download_status_file(client, update_study_ids, party_id):
     """Retrieves JSON of download status for all study IDs."""
     studies_file = join(dirname(__file__), 'studies.json')
+
     if not isfile(studies_file):
         status = {
             study_id: 0
-            for study_id in client.get_study_ids()
+            for study_id in client.get_study_ids(party_id=party_id)
         }
         write_json(studies_file, status)
+    else:
+        if update_study_ids:
+            status = read_json(studies_file)
+            add_to_status = {
+                study_id: 0
+                for study_id in client.get_study_ids(party_id=party_id) if study_id not in status.keys()
+            }
+            status.update(add_to_status)
+            write_json(studies_file, status)
     return studies_file
 
 
-def run(client, path_out, channel_group_to_download):
+def run(client, path_out, update_study_ids, channel_groups_to_download, channels_to_download, party_id):
     """Downloads all data available on Seer's public API."""
     if path_out:
         if not isdir(path_out):
@@ -35,44 +45,47 @@ def run(client, path_out, channel_group_to_download):
     if not isdir(output_dir):
         mkdir(output_dir)
 
-    download_status_file = get_download_status_file(client)
+    download_status_file = get_download_status_file(client, update_study_ids, party_id)
     download_status = read_json(download_status_file)
     study_ids = [study_id for study_id in download_status if not download_status[study_id]]
 
-    for study_id in study_ids:
-        attempts = 0
-        while True:
-            try:
+    attempts = 0
+    while True:
+        try:
+            for study_id in study_ids:
                 if attempts != 0:
                     time.sleep(3)
                     client = SeerConnect()
                 downloader = DataDownloader(client, study_id, output_dir)
                 # Download channel data
-                downloader.download_channel_data(channel_group_to_download)
+                downloader.download_channel_data(channel_groups_to_download, channels_to_download)
                 download_status[study_id] = 1
                 write_json(download_status_file, download_status)
 
-            except ReadTimeoutError:
-                attempts += 1
-                for i in range(5, 0, -1):
-                    sys.stdout.write(f'ReadTimeoutError. Re-trying after a short break... {str(i)}')
-                    sys.stdout.flush()
-                    time.sleep(1)
-            print('Download completed.')
-            return
+        except ReadTimeoutError:
+            attempts += 1
+            for i in range(5, 0, -1):
+                sys.stdout.write(f'ReadTimeoutError. Re-trying after a short break... {str(i)}')
+                sys.stdout.flush()
+                time.sleep(1)
 
-        # If user reaches 5 attempts, break and request user to return later
-        if attempts == 5:
-            print("ReadTimeoutError! Number of tries exceeded. Please re-run \
-                this script at a later time.")
-            break
+            # If user reaches 5 attempts, break and request user to return later
+            if attempts == 5:
+                print("ReadTimeoutError! Number of tries exceeded. Please re-run \
+                    this script at a later time.")
+                break
+
+    print('Download completed.')
     return
 
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
     parser.add_argument("-o", "--outpath", help="Path for data to be saved (optional).")
-    parser.add_argument("-cg", "--channelgroup", help="Name of channel group to download.")
+    parser.add_argument("-u", "--update", default=False, help="Updates list of cached study IDs (optional). Default is False.")
+    parser.add_argument("-cg", "--channelgroups", nargs="+", help="Name of channel groups to download (optional).")
+    parser.add_argument("-c", "--channels", nargs="+", help="Name of channels to download (optional).")
+    parser.add_argument("-p", "--party_id", help="Party ID for specific organisation to download studies from.")
     args = parser.parse_args()
-
-    run(SeerConnect(), args.outpath, args.channelgroup)
+    breakpoint()
+    run(SeerConnect(), args.outpath, args.update, args.channelgroups, args.channels, args.party_id)

--- a/Examples/downloader/downloader.py
+++ b/Examples/downloader/downloader.py
@@ -64,12 +64,18 @@ class DataDownloader:
 
             yield data, segment_file
 
-    def download_channel_data(self, channel_group_to_download=None):
+    def download_channel_data(self, channel_groups_to_download=None, channels_to_download=None):
         print(f'Downloading channel data for {self.study_name}...')
 
+        if isinstance(channel_groups_to_download, str):
+            channel_groups_to_download = list(channel_groups_to_download)
+
         for (channel_group, channel) in self.get_channels():
-            if channel_group_to_download and channel_group != channel_group_to_download:
+            if channel_groups_to_download and channel_group not in channel_groups_to_download:
                 continue
+            if channels_to_download and channel not in channels_to_download:
+                continue
+
             # Create folder
             folder_out = join(self.folder_out, channel_group)
             if not isdir(folder_out):
@@ -93,7 +99,6 @@ class DataDownloader:
                                                                     segment_ids):
                 # Save segment data to JSON
                 segment_data.to_parquet(segment_file)
-        print('Done.')
 
     def download_label_data(self):
         print(f'Downloading label data for {self.study_name}...')

--- a/Examples/downloader/downloader.py
+++ b/Examples/downloader/downloader.py
@@ -64,10 +64,13 @@ class DataDownloader:
 
             yield data, segment_file
 
-    def download_channel_data(self):
+    def download_channel_data(self, channel_group_to_download=None):
         print(f'Downloading channel data for {self.study_name}...')
 
         for (channel_group, channel) in self.get_channels():
+            if channel_group_to_download:
+                if not channel_group == channel_group_to_download:
+                    continue
             # Create folder
             folder_out = join(self.folder_out, channel_group)
             if not isdir(folder_out):


### PR DESCRIPTION
This is a modified version of `msg_data_downloader.py` in the Examples folder. By default, all studies, channel groups and channels are downloaded, unless a specific channel group is specified on input.

This script could be developed if there is a need for it in the future.