### PR TITLE
Fix use of pyjwt token to work with pre and post pyjwt 2.0.0

### DIFF
--- a/seerpy/auth.py
+++ b/seerpy/auth.py
@@ -404,7 +404,14 @@ class SeerApiKeyAuth(BaseAuth):
         timestamp = int(datetime.datetime.now(tz=datetime.timezone.utc).timestamp())
         payload = {'keyId': self.api_key_id, 'iat': timestamp}
         token = jwt.encode(payload, self.api_key, algorithm='RS256')
-        return {"Authorization": "Bearer " + token.decode('utf-8')}
+
+        try:
+            token = token.decode('utf-8')
+        except AttributeError:
+            # prior to PyJWT 2.0.0 jwt.encode returned a byte object
+            pass
+
+        return {"Authorization": "Bearer " + token}
 
     def handle_query_error_pre_sleep(self, ex):
         if 'NOT_AUTHENTICATED' in str(ex):

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -161,6 +161,22 @@ class TestSeerApiKeyAuth:
         }
         open_mock.assert_called_with('path/seerpy.pem', 'r')
 
+    @mock.patch('jwt.encode', autospec=True, return_value="an_unencoded_key")
+    def test_get_connection_parameters_no_decode(self, unused_jwt_encode, unused_glob, open_mock):
+
+        apikey_auth = SeerApiKeyAuth(api_key_id='id', api_key_path='path/seerpy.pem')
+        params = apikey_auth.get_connection_parameters()
+
+        assert params == {
+            'url': 'https://sdk-au.seermedical.com/api/graphql',
+            'headers': {
+                'Authorization': 'Bearer an_unencoded_key'
+            },
+            'use_json': True,
+            'timeout': 30
+        }
+        open_mock.assert_called_with('path/seerpy.pem', 'r')
+
     def test_no_files(self, mock_glob, open_mock):
         # setup
         mock_glob.return_value = []


### PR DESCRIPTION
The 2.0.0 version of PyJWT returns a str instead of a byte array from encode, so our call to decode throws an exception.
This catches that exception and passes through so we will work with either version.