### PR TITLE
Update seerpy.py

### DIFF
--- a/seerpy/seerpy.py
+++ b/seerpy/seerpy.py
@@ -1080,6 +1080,7 @@ class SeerConnect:  # pylint: disable=too-many-public-methods
             for document in study['documents']:
                 document['document.id'] = document.pop('id')
                 document['document.name'] = document.pop('name')
+                document['document.uploaded'] = document.pop('uploaded')
                 document['id'] = study['id']
                 document['name'] = study['name']
                 documents.append(document)


### PR DESCRIPTION
Added functionality to return the date of when a report was uploaded to the Seer Cloud. I need this functionality to exclude older reports from analysis. 

the new line is document['document.uploaded'] = document.pop('uploaded')

Note that the graphiql request in graphql.py already requests the uploaded date (in "GET_DOCUMENTS_FOR_STUDY_IDS_PAGED"). this request returns
 documents {
                id
                name
                **uploaded**
                fileSize
                downloadFileUrl
            }
