### PR TITLE
Update json_normalize method to remove warning

### DIFF
--- a/seerpy/seerpy.py
+++ b/seerpy/seerpy.py
@@ -45,7 +45,7 @@ import json
 from gql import gql, Client as GQLClient
 from gql.transport.requests import RequestsHTTPTransport
 import pandas as pd
-from pandas.io.json import json_normalize
+from pandas import json_normalize
 import requests
 
 from . import auth


### PR DESCRIPTION
Are we able to update the method `json_normalize` on Pandas to avoid the warning @bjdoyle? I don't think we have a specified version of Pandas in requirements.
