### PR TITLE
Cope with missing data and s3 performance errors when getting data.

### DIFF
--- a/seerpy/utils.py
+++ b/seerpy/utils.py
@@ -65,12 +65,12 @@ def download_channel_data(data_q, download_function):
 
         if meta_data['channelGroups.timestamped']:
             # timestamped data is not stored in records as EDF data is
-            # it is just a sequence of (ts, ch1, ch2, ..., chN), (ts, ch1, ch2, ..., chN), ...
+            # it is just a sequence of (ts1, ch1, ch2, ..., chN), (ts2, ch1, ch2, ..., chN), ...
             # the timestamp is milliseconds relative to chunk start
             column_names = ['time'] + channel_names
             data = data.reshape(-1, len(column_names))
         else:
-            # EDF data is in the format [record 1: (ch1 sample1, ch1 sample2, ..., ch2 sampleN),
+            # EDF data is in the format [record 1: (ch1 sample1, ch1 sample2, ..., ch1 sampleN),
             # (ch2 sample1, ch2 sample2, ..., ch2 sampleN), ...][record2: ...], ..., [recordN: ...]
             data = data.reshape(-1, len(channel_names),
                                 int(meta_data['channelGroups.samplesPerRecord']))
@@ -293,7 +293,7 @@ def get_channel_data(study_metadata, segment_urls, download_function=requests.ge
                                 na_position='last')
         data = data.reset_index(drop=True)
     else:
-        data = None
+        data = pd.DataFrame()
 
     return data
 

--- a/seerpy/utils.py
+++ b/seerpy/utils.py
@@ -6,6 +6,7 @@ Copyright 2017 Seer Medical Pty Ltd, Inc. or its affiliates. All Rights Reserved
 """
 import functools
 import gzip
+import json
 from multiprocessing import Pool
 import os
 
@@ -179,11 +180,11 @@ def _get_data_chunk(study_id, meta_data, download_function):
             break
 
         print(f'download_channel_data: {status_code} status code returned')
+        print('response content', data)
         print('study_id', study_id)
         print('dataChunks.url', meta_data['dataChunks.url'])
         print(f"dataChunks.time {meta_data['dataChunks.time']:.2f}")
         print('meta_data', meta_data)
-        print('response', response)
 
         if status_code == 404:
             # we sometimes get chunk urls which don't exist
@@ -195,6 +196,8 @@ def _get_data_chunk(study_id, meta_data, download_function):
             message = 'Unable to read chunk - most likely a performance error'
             if i < (max_attempts - 1):
                 print(message, '- retrying')
+                # if we find that we get multiple errors, particularly 503, then we should consider
+                # sleeping between retries with backoff, but keep it simple for now
                 continue
             print(message, '- max attempts exceeded')
 

--- a/seerpy/utils.py
+++ b/seerpy/utils.py
@@ -6,7 +6,6 @@ Copyright 2017 Seer Medical Pty Ltd, Inc. or its affiliates. All Rights Reserved
 """
 import functools
 import gzip
-import json
 from multiprocessing import Pool
 import os
 


### PR DESCRIPTION
2 related changes:
1. change seerpy.get_data_chunk_urls() to cope with missing data chunks (resulting from processing errors)
2. change utils.download_channel_data() to cope with missing data chunks (these are the result of upload errors) and also with s3 performance errors (it throws http 500 and 503 errors when it gets overloaded). In the case of 500 and 503 we will retry up to twice.
Also fixed a couple of errors in docstrings.