### PR TITLE
Read default sdk url from env var

### DIFF
--- a/seerpy/auth.py
+++ b/seerpy/auth.py
@@ -303,7 +303,7 @@ class SeerApiKeyAuth(BaseAuth):
                                                                     region)
 
         if not api_url:
-            api_url = f'https://sdk-{region}.seermedical.com/api'
+            api_url = os.getenv('SDK_API_BASE_URL', f'https://sdk-{region}.seermedical.com/api')
 
         super(SeerApiKeyAuth, self).__init__(api_url)
 

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -425,3 +425,14 @@ class TestSeerApiKeyAuth:
                            api_url=None)
 
         open_mock.assert_not_called()
+
+    @mock.patch.dict('os.environ', { 'SDK_API_BASE_URL': 'https://random-sdk.url' })
+    @mock.patch('jwt.encode', autospec=True, return_value="an_encoded_key".encode('utf-8'))
+    def test_api_url_read_from_env_var(self, unused_jwt_encode, mock_glob, open_mock):
+        apikey_auth = SeerApiKeyAuth(api_key_id='id', api_key_path=None, api_key='key')
+        params = apikey_auth.get_connection_parameters()
+
+        assert apikey_auth.api_url == 'https://random-sdk.url'
+        assert params['url'] == 'https://random-sdk.url/graphql'
+        open_mock.assert_not_called()
+        mock_glob.assert_not_called()


### PR DESCRIPTION
## :pencil: Description

This PR reads the default sdk url from the `SDK_API_BASE_URL` env var if exists. This is to allow for the override to be used in the `next` environment.

## :page_with_curl: Changes

* Read default sdk url from env var

## :white_check_mark: Testing

[Briefly outline the testing steps you have undertaken, including whether testing was done locally and/or on seer-next.]

- [x] Manually tested this change locally.
- [x] Tested this on seer-next (if there are substantial changes).
- [x] Added tests to cover the proposed changes (and if not, identify existing test cases).

## :clipboard: [Regulatory review](https://docs.google.com/document/d/1bddDpD8NLleMxsC3CRNTO_Yd4q4f5wgdiOl2wQBbBhM/edit)

[One of the following options must be checked. See above link for instructions regarding regulatory review of software updates.]

- [x] These changes don't meet the criteria requiring regulatory review.
- [ ] These changes require regulatory review (relevant approval is needed before merging).

## :airplane: Pre-flight checks

[All of the below must be checked before the PR can be merged.]

- [x] Completed this PR documentation with a sufficient level of detail (these are used as a record for regulatory purposes).
- [x] Added appropriate comments to my code where the code is not easily understood.
- [x] Updated any relevant documentation that may exist.
- [x] Added the appropriate [semver](https://semver.org/) label ("patch", "minor", or "major") to the PR.

## :link: PRs in set

* https://github.com/seermedical/seer-api-events/pull/154
* https://github.com/seermedical/seer-py/pull/127
* https://github.com/seermedical/seer-api/pull/1838
