### PR TITLE
Resolves #130 : Limit max items returned in paginated query

### DIFF
--- a/seerpy/graphql.py
+++ b/seerpy/graphql.py
@@ -408,6 +408,27 @@ GET_PATIENTS = """
         }
     }"""
 
+
+GET_PATIENTS_PAGED = """
+    query patientsPaged(
+                  $limit: PaginationAmount,
+                  $offset: Int) {
+        patients (limit: $limit, offset: $offset) {
+          id
+          user {
+              id
+              fullName
+              shortName
+              email
+              lastActive
+              lastInsightGenerated
+              preferredTimezone
+          }
+        }
+    }
+    """
+
+
 GET_DIARY_INSIGHTS_PAGED = """
     query patient($patient_id: String!,
                   $limit: PaginationAmount,

--- a/seerpy/graphql.py
+++ b/seerpy/graphql.py
@@ -671,6 +671,55 @@ def get_bookings_query_string(organisation_id, start_time, end_time):
             }""" % (organisation_id, start_time, end_time)
 
 
+# NOTE: This provides more flexibility than using `get_bookings_query_string()`
+#       eg, allowing null values for variables.
+# But it is not plug and play compatible with the returned value of that
+# function, so keeping this separate.
+# TODO: maybe remove get_bookings_query_string()
+ORGANIZATION_BOOKINGS = """
+    query organizationBookings($organization_id: String!, $startTime: Float, $endTime: Float, $includeCancelled: Boolean = false){
+        organisation(id: $organization_id) {
+            bookings(startTime: $startTime, endTime: $endTime, includeCancelled: $includeCancelled) {
+                id
+                equipmentItems {
+                    name
+                    equipmentType {
+                        type
+                    }
+                }
+                bookingTemplate {
+                    name
+                }
+                referral {
+                    id
+                }
+                startTime {
+                    datetime
+                    timezone
+                }
+                endTime {
+                    datetime
+                    timezone
+                }
+                patient {
+                    id
+                    user {
+                        fullName
+                    }
+                    studies {
+                        id
+                        name
+                    }
+                }
+                location {
+                        name
+                        suburb
+                        }
+            }
+        }
+    }"""
+
+
 def get_diary_study_label_groups_string(patient_id, limit, offset):
 
     return """

--- a/seerpy/seerpy.py
+++ b/seerpy/seerpy.py
@@ -577,7 +577,8 @@ class SeerConnect:  # pylint: disable=too-many-public-methods
         study_df: pd.DataFrame
             DataFrame with details of all matching studies
         """
-        studies = self.get_studies(limit=limit, search_term=search_term, party_id=party_id, max_items=max_items)
+        studies = self.get_studies(limit=limit, search_term=search_term, party_id=party_id,
+            max_items=max_items)
         studies_dataframe = json_normalize(studies).sort_index(axis=1)
         return studies_dataframe.drop('patient', errors='ignore', axis='columns')
 
@@ -787,7 +788,8 @@ class SeerConnect:  # pylint: disable=too-many-public-methods
         return data_chunk_urls
 
     # pylint:disable=too-many-arguments
-    def get_labels(self, study_id, label_group_id, from_time=0, to_time=9e12, limit=200, offset=0, max_items=None):
+    def get_labels(self, study_id, label_group_id, from_time=0, to_time=9e12, limit=200, offset=0,
+        max_items=None):
         """
         Get labels for a given study and label group.
 
@@ -1625,7 +1627,8 @@ class SeerConnect:  # pylint: disable=too-many-public-methods
 
         return response['organisation']['bookings']
 
-    def get_all_bookings_dataframe(self, organisation_id, start_time, end_time, include_cancelled=False):
+    def get_all_bookings_dataframe(self, organisation_id, start_time, end_time,
+        include_cancelled=False):
         """
         Get all bookings for any studies that are active at any point between
         `start_time` and `end_time` as a DataFrame. See `get_all_bookings()`.
@@ -1915,7 +1918,8 @@ class SeerConnect:  # pylint: disable=too-many-public-methods
                                            max_items=max_items
                                            )
 
-    def get_mood_survey_results_dataframe(self, survey_template_ids, limit=200, offset=0, max_items=None):
+    def get_mood_survey_results_dataframe(self, survey_template_ids, limit=200, offset=0,
+        max_items=None):
         """
         Get mood survey results as a DataFrame. See `get_mood_survey_results()`
         for details.

--- a/seerpy/seerpy.py
+++ b/seerpy/seerpy.py
@@ -234,14 +234,14 @@ class SeerConnect:  # pylint: disable=too-many-public-methods
                                           party_id=party_id)
 
             # select the part of the response we are interested in
-            response = utils.get_nested_dict_item(response, *object_path)
+            response = utils.get_nested_dict_item(response, object_path)
 
 
             # select the part of the response which can vary. if iteration_path is None this will be
             # the same as the part of the response we are interested in
             response_increment = response
             if iteration_path:
-                response_increment = utils.get_nested_dict_item(response_increment, *iteration_path)
+                response_increment = utils.get_nested_dict_item(response_increment, iteration_path)
             if not response_increment:
                 # if the part of the response which varies is empty, we are finished iterating
                 break
@@ -257,7 +257,7 @@ class SeerConnect:  # pylint: disable=too-many-public-methods
                 # otherwise add the response increment to the existing result at the correct level
                 values_container = result
                 if iteration_path:
-                    values_container = utils.get_nested_dict_item(values_container, *iteration_path)
+                    values_container = utils.get_nested_dict_item(values_container, iteration_path)
                 values_container.extend(response_increment)
 
             offset += limit

--- a/seerpy/seerpy.py
+++ b/seerpy/seerpy.py
@@ -1616,6 +1616,7 @@ class SeerConnect:  # pylint: disable=too-many-public-methods
             'patient', 'referral', 'equipmentItems', and 'location'
         """
         # TODO: paginate using the new resource schema
+        assert (start_time is not None) and (end_time is not None), "start_time and end_time should not be None"
         query_string = graphql.ORGANIZATION_BOOKINGS
         vars = dict(organization_id=organisation_id, startTime=start_time, endTime=end_time,
                     includeCancelled=include_cancelled)

--- a/seerpy/seerpy.py
+++ b/seerpy/seerpy.py
@@ -184,12 +184,12 @@ class SeerConnect:  # pylint: disable=too-many-public-methods
             vary with each query iteration. If None then the response varies at
             the path given by object_path.
 
-            Eg: We may be interested in the surveys for a user. The heirarchy
-            will look something like ["user", "surveys"]. We are interested in
-            keeping the user information, although this doesnt change with each
-            iteration, so we set `object_path=["user"]`. But we actually want
-            to iterate through the survey  information, which does change with
-            each iteration, so we set `iteration_path=["surveys"]`
+            e.g. We may be interested in the surveys for a user, while keeping
+            information about the user. The hierarchy will look something like
+            ["user", "surveys"]. At the "user" level, it contains the user
+            information which we want to keep, so we set `object_path=["user"]`.
+            But we cannot iterate at this level, we want to iterate at the
+            "surveys" level, so we set `iteration_path=["surveys"]`
         party_id : str, optional
             The organisation/entity to specify for the query
         max_items: int, optional

--- a/seerpy/seerpy.py
+++ b/seerpy/seerpy.py
@@ -1615,7 +1615,7 @@ class SeerConnect:  # pylint: disable=too-many-public-methods
             Booking information, with keys including 'id', 'startTime', 'endTime',
             'patient', 'referral', 'equipmentItems', and 'location'
         """
-        # TODO: request changes to seer-api so we can perform pagination
+        # TODO: paginate using the new resource schema
         query_string = graphql.ORGANIZATION_BOOKINGS
         vars = dict(organization_id=organisation_id, startTime=start_time, endTime=end_time,
                     includeCancelled=include_cancelled)

--- a/seerpy/seerpy.py
+++ b/seerpy/seerpy.py
@@ -171,7 +171,8 @@ class SeerConnect:  # pylint: disable=too-many-public-methods
         variable_values : dict, optional
             Values for GraphQL to substitute into the query
         limit : int
-            Batch size for repeated API calls
+            Batch size for repeated API calls. Does not affect the total number
+            of items retrieved
         object_path : list of str
             One or more levels of key giving the path to the object to be returned
             e.g. ['userCohort', 'users'] for a query response of
@@ -801,7 +802,8 @@ class SeerConnect:  # pylint: disable=too-many-public-methods
         to_time : int, optional
             Timestamp in msec - only retrieve data up until this point
         limit : int, optional
-            Batch size for repeated API calls
+            Batch size for repeated API calls. Does not affect the total number
+            of items retrieved
         offset : int, optional
             Index of first label to retrieve
         max_items: int, optional
@@ -1171,7 +1173,8 @@ class SeerConnect:  # pylint: disable=too-many-public-methods
         patient_id : str
             The patient ID
         limit : int, optional
-            Optional batch size for repeated API calls
+            Batch size for repeated API calls. Does not affect the total number
+            of items retrieved
         offset : int, optional
             Optional index of first record to return
         max_items: int, optional
@@ -2051,7 +2054,8 @@ class SeerConnect:  # pylint: disable=too-many-public-methods
         user_cohort_id : str
             ID of the user cohort to retrieve
         limit : int, optional
-            Batch size for repeated API calls
+            Batch size for repeated API calls. Does not affect the total number
+            of items retrieved
         offset : int, optional
             Index of the first result to return
         max_items: int, optional

--- a/seerpy/seerpy.py
+++ b/seerpy/seerpy.py
@@ -177,16 +177,17 @@ class SeerConnect:  # pylint: disable=too-many-public-methods
             {"userCohort": {"users": [{"id": "user1"}, {"id": "user2"}]}}
             would give [{"id": "user1"}, {"id": "user2"}]
         iteration_path : list of str, optional
-            None (default), one, or more levels of key giving the path to the node where the
-            response can vary with each query iteration. If None then the response varies at the
-            path given by object_path
+            None (default), one, or more levels of key giving the path to the
+            node (relative to the `object_path` level) where the response can
+            vary with each query iteration. If None then the response varies at
+            the path given by object_path.
 
             Eg: We may be interested in the surveys for a user. The heirarchy
             will look something like ["user", "surveys"]. We are interested in
             keeping the user information, although this doesnt change with each
             iteration, so we set `object_path=["user"]`. But we actually want
             to iterate through the survey  information, which does change with
-            each iteration, so we set `iteration_path=["user", "surveys"]`
+            each iteration, so we set `iteration_path=["surveys"]`
         party_id : str, optional
             The organisation/entity to specify for the query
 

--- a/seerpy/seerpy.py
+++ b/seerpy/seerpy.py
@@ -193,7 +193,7 @@ class SeerConnect:  # pylint: disable=too-many-public-methods
         party_id : str, optional
             The organisation/entity to specify for the query
         max_items: int, optional
-            max number of items to return. In the case of queries containing
+            Max number of items to return. In the case of queries containing
             nested lists of items it only limits the number of items specified
             on the `iteration_path` level of the heirarchy (this defaults to
             `object_path` if no argument is passed to `iteration_path` )
@@ -212,9 +212,9 @@ class SeerConnect:  # pylint: disable=too-many-public-methods
         responses: list of dict
             List of query result dictionaries
         """
-        variable_values = deepcopy(variable_values) # prevent local changes affecting external one
+        variable_values = deepcopy(variable_values)  # prevent local changes affecting external one
         variable_values['limit'] = limit
-        offset = variable_values.get('offset', 0) # Try get offset from variable values if it exists
+        offset = variable_values.get('offset', 0)  # Try get offset from variable values if exists
         result = []
         total_items_returned = 0
         remaining_items = 0
@@ -248,7 +248,7 @@ class SeerConnect:  # pylint: disable=too-many-public-methods
 
             # Update the number of items received
             total_items_returned += len(response)
-            
+
             if not result:
                 # if this is the first response, save it
                 result = response
@@ -1620,10 +1620,6 @@ class SeerConnect:  # pylint: disable=too-many-public-methods
         vars = dict(organization_id=organisation_id, startTime=start_time, endTime=end_time,
                     includeCancelled=include_cancelled)
         response = self.execute_query(query_string, variable_values=vars)
-
-        # query_string = graphql.get_bookings_query_string(organisation_id, start_time, end_time)
-        # response = self.execute_query(query_string)
-
         return response['organisation']['bookings']
 
     def get_all_bookings_dataframe(self, organisation_id, start_time, end_time,

--- a/seerpy/seerpy.py
+++ b/seerpy/seerpy.py
@@ -180,6 +180,13 @@ class SeerConnect:  # pylint: disable=too-many-public-methods
             None (default), one, or more levels of key giving the path to the node where the
             response can vary with each query iteration. If None then the response varies at the
             path given by object_path
+
+            Eg: We may be interested in the surveys for a user. The heirarchy
+            will look something like ["user", "surveys"]. We are interested in
+            keeping the user information, although this doesnt change with each
+            iteration, so we set `object_path=["user"]`. But we actually want
+            to iterate through the survey  information, which does change with
+            each iteration, so we set `iteration_path=["user", "surveys"]`
         party_id : str, optional
             The organisation/entity to specify for the query
 

--- a/seerpy/seerpy.py
+++ b/seerpy/seerpy.py
@@ -548,9 +548,9 @@ class SeerConnect:  # pylint: disable=too-many-public-methods
         """
         variable_values = {'search_term': search_term}
         return self.get_paginated_response(graphql.GET_STUDIES_BY_SEARCH_TERM_PAGED,
-                                           variable_values=variable_values,
-                                           limit=limit,
-                                           object_path=['studies'],
+                                           variable_values,
+                                           limit,
+                                           ['studies'],
                                            party_id=party_id,
                                            max_items=max_items
                                            )
@@ -829,7 +829,6 @@ class SeerConnect:  # pylint: disable=too-many-public-methods
                                            ['labelGroup', 'labels'],
                                            max_items=max_items
                                            )
-
 
     # pylint:disable=too-many-arguments
     def get_labels_dataframe(self, study_id, label_group_id, from_time=0, to_time=9e12, limit=200,
@@ -1190,10 +1189,10 @@ class SeerConnect:  # pylint: disable=too-many-public-methods
         """
         variable_values = {'patient_id': patient_id}
         return self.get_paginated_response(graphql.GET_DIARY_INSIGHTS_PAGED,
-                                   variable_values=variable_values,
-                                   limit=limit,
-                                   object_path=['patient'],
-                                   iteration_path=['insights'],
+                                   variable_values,
+                                   limit,
+                                   ['patient'],
+                                   ['insights'],
                                    max_items=max_items
                                    )
 
@@ -1742,10 +1741,10 @@ class SeerConnect:  # pylint: disable=too-many-public-methods
             'to_time': to_time
         }
         return self.get_paginated_response(graphql.GET_LABELS_FOR_DIARY_STUDY_PAGED,
-                                           variable_values=variable_values,
-                                           limit=limit,
-                                           object_path=['patient', 'diaryStudy'],
-                                           iteration_path=['labelGroup', 'labels'],
+                                           variable_values,
+                                           limit,
+                                           ['patient', 'diaryStudy'],
+                                           ['labelGroup', 'labels'],
                                            max_items=max_items,
                                            )
 
@@ -1913,9 +1912,9 @@ class SeerConnect:  # pylint: disable=too-many-public-methods
         """
         variable_values = {'survey_template_ids': survey_template_ids}
         return self.get_paginated_response(graphql.GET_MOOD_SURVEY_RESULTS_PAGED,
-                                           variable_values=variable_values,
-                                           limit=limit,
-                                           object_path=['surveys'],
+                                           variable_values,
+                                           limit,
+                                           ['surveys'],
                                            max_items=max_items
                                            )
 
@@ -1978,12 +1977,11 @@ class SeerConnect:  # pylint: disable=too-many-public-methods
         """
         variable_values = {'study_cohort_id': study_cohort_id}
         results = self.get_paginated_response(graphql.GET_STUDY_IDS_IN_STUDY_COHORT_PAGED,
-                                   variable_values=variable_values,
-                                   limit=limit,
-                                   object_path=['studyCohort', 'studies'],
+                                   variable_values,
+                                   limit,
+                                   ['studyCohort', 'studies'],
                                    max_items=max_items,
                                    )
-
         return [study['id'] for study in results]
 
     def create_study_cohort(self, name, description=None, key=None, study_ids=None):
@@ -2073,12 +2071,11 @@ class SeerConnect:  # pylint: disable=too-many-public-methods
         """
         variable_values = {'user_cohort_id': user_cohort_id}
         results = self.get_paginated_response(graphql.GET_USER_IDS_IN_USER_COHORT_PAGED,
-                                   variable_values=variable_values,
-                                   limit=limit,
-                                   object_path=['userCohort', 'users'],
+                                   variable_values,
+                                   limit,
+                                   ['userCohort', 'users'],
                                    max_items=max_items
                                    )
-
         return [user['id'] for user in results]
 
     def create_user_cohort(self, name, description=None, key=None, user_ids=None):

--- a/seerpy/seerpy.py
+++ b/seerpy/seerpy.py
@@ -248,8 +248,7 @@ class SeerConnect:  # pylint: disable=too-many-public-methods
 
             # Update the number of items received
             total_items_returned += len(response)
-            # print(f"items: {len(response)}  limit: {limit}  fetched: {total_items_returned} remain: {remaining_items}") # for debuging purposes
-
+            
             if not result:
                 # if this is the first response, save it
                 result = response

--- a/seerpy/seerpy.py
+++ b/seerpy/seerpy.py
@@ -1976,7 +1976,7 @@ class SeerConnect:  # pylint: disable=too-many-public-methods
             Unique IDs, each identifying a study
         """
         variable_values = {'study_cohort_id': study_cohort_id}
-        return self.get_paginated_response(graphql.GET_STUDY_IDS_IN_STUDY_COHORT_PAGED,
+        results = self.get_paginated_response(graphql.GET_STUDY_IDS_IN_STUDY_COHORT_PAGED,
                                    variable_values=variable_values,
                                    limit=limit,
                                    object_path=['studyCohort', 'studies'],
@@ -2071,7 +2071,7 @@ class SeerConnect:  # pylint: disable=too-many-public-methods
             User IDs that are in the cohort
         """
         variable_values = {'user_cohort_id': user_cohort_id}
-        return self.get_paginated_response(graphql.GET_USER_IDS_IN_USER_COHORT_PAGED,
+        results = self.get_paginated_response(graphql.GET_USER_IDS_IN_USER_COHORT_PAGED,
                                    variable_values=variable_values,
                                    limit=limit,
                                    object_path=['userCohort', 'users'],

--- a/seerpy/seerpy.py
+++ b/seerpy/seerpy.py
@@ -535,7 +535,7 @@ class SeerConnect:  # pylint: disable=too-many-public-methods
         party_id : str
             The organisation/entity to specify for the query
         max_items: int, optional
-            max number of studies to return.
+            Max number of studies to return.
 
         Returns
         -------
@@ -569,7 +569,7 @@ class SeerConnect:  # pylint: disable=too-many-public-methods
         party_id : str, optional
             The organisation/entity to specify for the query
         max_items: int, optional
-            max number of studies to return.
+            Max number of studies to return.
 
         Returns
         -------
@@ -808,7 +808,7 @@ class SeerConnect:  # pylint: disable=too-many-public-methods
         offset : int, optional
             Index of first label to retrieve
         max_items: int, optional
-            max number of labels to return.
+            Max number of labels to return.
 
         Returns
         -------
@@ -1080,7 +1080,7 @@ class SeerConnect:  # pylint: disable=too-many-public-methods
             Batch size for repeated API calls. Does not affect the total number
             of items retrieved
         max_items: int, optional
-            max number of patients to return
+            Max number of patients to return
 
         Returns
         -------
@@ -1109,7 +1109,7 @@ class SeerConnect:  # pylint: disable=too-many-public-methods
             Batch size for repeated API calls. Does not affect the total number
             of items retrieved
         max_items: int, optional
-            max number of patients to return
+            Max number of patients to return
 
         Returns
         -------
@@ -1179,7 +1179,7 @@ class SeerConnect:  # pylint: disable=too-many-public-methods
         offset : int, optional
             Optional index of first record to return
         max_items: int, optional
-            max number of diary insights to return.
+            Max number of diary insights to return.
 
         Returns
         -------
@@ -1722,7 +1722,7 @@ class SeerConnect:  # pylint: disable=too-many-public-methods
         offset : int, optional
             The index of the first label group to return
         max_items: int, optional
-            max number of study labels to return.
+            Max number of study labels to return.
 
         Returns
         -------
@@ -1767,7 +1767,7 @@ class SeerConnect:  # pylint: disable=too-many-public-methods
         offset : int, optional
             The index of the first label group to return
         max_items: int, optional
-            max number of study labels to return.
+            Max number of study labels to return.
 
         Returns
         -------
@@ -1897,7 +1897,7 @@ class SeerConnect:  # pylint: disable=too-many-public-methods
         offset : int, optional
             Index of the first result to return
         max_items: int, optional
-            max number of surveys to return.
+            Max number of surveys to return.
 
         Returns
         -------
@@ -1930,7 +1930,7 @@ class SeerConnect:  # pylint: disable=too-many-public-methods
         offset : int, optional
             Index of the first result to return
         max_items: int, optional
-            max number of surveys to return.
+            Max number of surveys to return.
 
         Returns
         -------
@@ -1964,7 +1964,7 @@ class SeerConnect:  # pylint: disable=too-many-public-methods
         offset : int, optional
             Index of the first result to return
         max_items: int, optional
-            max number of study ids to return.
+            Max number of study ids to return.
 
         Returns
         -------
@@ -2058,7 +2058,7 @@ class SeerConnect:  # pylint: disable=too-many-public-methods
         offset : int, optional
             Index of the first result to return
         max_items: int, optional
-            max number of studies to return.
+            Max number of studies to return.
 
         Returns
         -------

--- a/seerpy/seerpy.py
+++ b/seerpy/seerpy.py
@@ -1197,7 +1197,7 @@ class SeerConnect:  # pylint: disable=too-many-public-methods
         return response['patient']['diary']['createdAt']
 
     def get_diary_labels(self, patient_id, label_type='all', offset=0, limit=100, from_time=0,
-                         to_time=9e12, from_duration=0, to_duration=9e12, max_items=None):
+                         to_time=9e12, from_duration=0, to_duration=9e12):
         """
         Retrieve diary label groups and labels for a given patient.
 
@@ -1224,8 +1224,6 @@ class SeerConnect:  # pylint: disable=too-many-public-methods
         to_duration : int, optional
             Time in milliseconds to apply a range filter on the duration of labels.
             Retrieves labels of duration < to_duration
-        max_items: int, optional
-            max number of diary labels to return
 
         Returns
         -------
@@ -1284,15 +1282,10 @@ class SeerConnect:  # pylint: disable=too-many-public-methods
         return label_results
 
     def get_diary_labels_dataframe(self, patient_id, label_type='all', offset=0, limit=100,
-                                   from_time=0, to_time=9e12, from_duration=0, to_duration=9e12, max_items=None):
+                                   from_time=0, to_time=9e12, from_duration=0, to_duration=9e12):
         """
         Get all diary label groups and labels for a given patient as a DataFrame.
         See `get_diary_labels()` for details.
-
-        TODO: docstring for this function
-
-            max_items: int, optional
-                max number of diary labels to return.
 
         Returns
         -------

--- a/seerpy/seerpy.py
+++ b/seerpy/seerpy.py
@@ -1068,7 +1068,7 @@ class SeerConnect:  # pylint: disable=too-many-public-methods
             return pd.DataFrame()
         return json_normalize(patient).sort_index(axis=1)
 
-    def get_patients(self, party_id=None, limit=50, max_items=None):
+    def get_patients(self, party_id=None, limit=5000, max_items=None):
         """
         Get available patient IDs and user names.
 
@@ -1097,7 +1097,7 @@ class SeerConnect:  # pylint: disable=too-many-public-methods
                                     )
         return response
 
-    def get_patients_dataframe(self, party_id=None, limit=50, max_items=None):
+    def get_patients_dataframe(self, party_id=None, limit=5000, max_items=None):
         """
         Get available patient IDs and user names as a DataFrame.
 

--- a/seerpy/seerpy.py
+++ b/seerpy/seerpy.py
@@ -823,9 +823,10 @@ class SeerConnect:  # pylint: disable=too-many-public-methods
             'to_time': to_time
         }
         return self.get_paginated_response(graphql.GET_LABELS_PAGED,
-                                           variable_values=variable_values,
-                                           limit=limit,
-                                           object_path=['labelGroup', 'labels'],
+                                           variable_values,
+                                           limit,
+                                           ['study'],
+                                           ['labelGroup', 'labels'],
                                            max_items=max_items
                                            )
 

--- a/seerpy/utils.py
+++ b/seerpy/utils.py
@@ -522,6 +522,49 @@ def quote_str(value):
     '"some value"'
     """
     return f'"{value}"'
+
+
+def raises_error(error, func, *args, **kwargs):
+    """
+    Given an Error, a function object, along with the arguments and keyword
+    arguments to pass to the function, it returns True, of calling the function
+    with those arguments raises the error you expected.
+
+    Parameters
+    ----------
+    error: Exception object
+        The Error/Exception you expect to be thrown
+    func:   function object
+        The function to run
+    *args:
+        positional arguments to pass to `func`
+    **kwargs:
+        keyword arguments to pass to `func`
+
+    Returns
+    ----------
+    bool
+        Whether it throws the expected error
+
+    Examples
+    ----------
+    >>> raises_error(ZeroDivisionError, lambda x: x/0, 4)
+    True
+
+    Tests
+    ----------
+    >>> assert raises_error(ZeroDivisionError, lambda x: x/0, 4), "Failed Test"
+    >>> assert raises_error(FileNotFoundError, lambda x: x/0, 4) == False, "Failed Test"
+    >>> assert raises_error(KeyError, lambda d, k: d[k], dict(b=42), "c"), "Failed Test"
+    """
+    try:
+        func(*args, **kwargs)
+    except error:
+        return True
+    except:
+        return False
+
+
 def get_nested_dict_item(d, *keys, allow_missing_keys=False, default=None):
     """
     Given a dictionary with potentially many nested dictionaries, get the
@@ -565,6 +608,7 @@ def get_nested_dict_item(d, *keys, allow_missing_keys=False, default=None):
     >>>
     >>> assert get_nested_dict_item(d1, "a", "b", "c") == 42, "Failed Test"
     >>> assert get_nested_dict_item(d1, "a", "x", "y", allow_missing_keys=True, default=999) == 999, "Failed Test"
+    >>> assert raises_error(KeyError, get_nested_dict_item, d1, "a", "x", "y", allow_missing_keys=False), "Failed Test"
 
     Credit
     ----------

--- a/seerpy/utils.py
+++ b/seerpy/utils.py
@@ -524,7 +524,7 @@ def quote_str(value):
     return f'"{value}"'
 
 
-def get_nested_dict_item(dct, keys, allow_missing_keys=False, default=None):
+def get_nested_dict_item(input_dict, keys, allow_missing_keys=False, default=None):
     """
     Given a dictionary with potentially many nested dictionaries, get the
     value of one of the nested keys by providing the sequence of keys as
@@ -532,7 +532,7 @@ def get_nested_dict_item(dct, keys, allow_missing_keys=False, default=None):
 
     Parameters
     ----------
-    dct: dict
+    input_dict: dict
         The dictionary
     keys: list of str
         The sequence of keys to traverse along the heirarchy of the dictionary
@@ -576,6 +576,6 @@ def get_nested_dict_item(dct, keys, allow_missing_keys=False, default=None):
     Based on this code: https://stackoverflow.com/a/46890853
     """
     if allow_missing_keys:
-        return functools.reduce(lambda d, key: d.get(key, default) if isinstance(d, dict) else default, keys, dct)
+        return functools.reduce(lambda d, key: d.get(key, default) if isinstance(d, dict) else default, keys, input_dict)
     else:
-        return functools.reduce(lambda d, key: d[key], keys, dct)
+        return functools.reduce(lambda d, key: d[key], keys, input_dict)

--- a/seerpy/utils.py
+++ b/seerpy/utils.py
@@ -565,7 +565,7 @@ def raises_error(error, func, *args, **kwargs):
         return False
 
 
-def get_nested_dict_item(d, *keys, allow_missing_keys=False, default=None):
+def get_nested_dict_item(dct, keys, allow_missing_keys=False, default=None):
     """
     Given a dictionary with potentially many nested dictionaries, get the
     value of one of the nested keys by providing the sequence of keys as
@@ -573,12 +573,12 @@ def get_nested_dict_item(d, *keys, allow_missing_keys=False, default=None):
 
     Parameters
     ----------
-    d: dict
+    dct: dict
         The dictionary
-    *keys:
+    keys: list of str
         The sequence of keys to traverse along the heirarchy of the dictionary
     allow_missing_keys: bool, optional
-        Allow travering along missing keys? If so, this acts like the
+        Allow traversing along missing keys? If so, this acts like the
         multi-level equivalent of the `get()` function for a dictionary,
         returning a default value.
         If this argument is not set, or set to False, then it raises a KeyError
@@ -595,9 +595,9 @@ def get_nested_dict_item(d, *keys, allow_missing_keys=False, default=None):
     Examples
     ----------
     >>> d1 = dict(a = dict(b = dict(c = 42 )))
-    >>> get_nested_dict_item(d1, "a", "b", "c")
+    >>> get_nested_dict_item(d1, ["a", "b", "c"])
     # 42
-    >>> get_nested_dict_item(d1, "a", "x", "y", allow_missing_keys=True, default=999)
+    >>> get_nested_dict_item(d1, ["a", "x", "y"], allow_missing_keys=True, default=999)
     # 999
 
     Tests
@@ -606,15 +606,17 @@ def get_nested_dict_item(d, *keys, allow_missing_keys=False, default=None):
     >>> d1 = dict(a=dict(b=dict(c=42)))
     >>> d2 = dict(a=dict(b=33, z=42))
     >>>
-    >>> assert get_nested_dict_item(d1, "a", "b", "c") == 42, "Failed Test"
-    >>> assert get_nested_dict_item(d1, "a", "x", "y", allow_missing_keys=True, default=999) == 999, "Failed Test"
-    >>> assert raises_error(KeyError, get_nested_dict_item, d1, "a", "x", "y", allow_missing_keys=False), "Failed Test"
+    >>> assert get_nested_dict_item(d1, ["a", "b", "c"]) == 42, "Failed Test"
+    >>> assert get_nested_dict_item(d1, ["a", "x", "y"], allow_missing_keys=True, default=999) == 999, "Failed Test"
+
+    >>> # TODO: test for checking that it throws a key error for the following:
+    >>> # get_nested_dict_item(d1, ["a", "x", "y"], allow_missing_keys=False)
 
     Credit
     ----------
     Based on this code: https://stackoverflow.com/a/46890853
     """
     if allow_missing_keys:
-        return functools.reduce(lambda dct, key: dct.get(key, default) if isinstance(dct, dict) else default, keys, d)
+        return functools.reduce(lambda d, key: d.get(key, default) if isinstance(d, dict) else default, keys, dct)
     else:
-        return functools.reduce(lambda dct, key: dct[key], keys, d)
+        return functools.reduce(lambda d, key: d[key], keys, dct)

--- a/seerpy/utils.py
+++ b/seerpy/utils.py
@@ -522,3 +522,55 @@ def quote_str(value):
     '"some value"'
     """
     return f'"{value}"'
+def get_nested_dict_item(d, *keys, allow_missing_keys=False, default=None):
+    """
+    Given a dictionary with potentially many nested dictionaries, get the
+    value of one of the nested keys by providing the sequence of keys as
+    arguments.
+
+    Parameters
+    ----------
+    d: dict
+        The dictionary
+    *keys:
+        The sequence of keys to traverse along the heirarchy of the dictionary
+    allow_missing_keys: bool, optional
+        Allow travering along missing keys? If so, this acts like the
+        multi-level equivalent of the `get()` function for a dictionary,
+        returning a default value.
+        If this argument is not set, or set to False, then it raises a KeyError
+        if the path of keys does not exist.
+    default: optional
+        If `allow_missing_keys` is set to True, and the path of keys does not
+        exist in the dictionary, then it returns this value.
+
+    Notes
+    ----------
+    Apart from the first argument, and the dictionary keys, you should pass all
+    other arguments as keyword arguments.
+
+    Examples
+    ----------
+    >>> d1 = dict(a = dict(b = dict(c = 42 )))
+    >>> get_nested_dict_item(d1, "a", "b", "c")
+    # 42
+    >>> get_nested_dict_item(d1, "a", "x", "y", allow_missing_keys=True, default=999)
+    # 999
+
+    Tests
+    ----------
+    >>> d0 = dict()
+    >>> d1 = dict(a=dict(b=dict(c=42)))
+    >>> d2 = dict(a=dict(b=33, z=42))
+    >>>
+    >>> assert get_nested_dict_item(d1, "a", "b", "c") == 42, "Failed Test"
+    >>> assert get_nested_dict_item(d1, "a", "x", "y", allow_missing_keys=True, default=999) == 999, "Failed Test"
+
+    Credit
+    ----------
+    Based on this code: https://stackoverflow.com/a/46890853
+    """
+    if allow_missing_keys:
+        return functools.reduce(lambda dct, key: dct.get(key, default) if isinstance(dct, dict) else default, keys, d)
+    else:
+        return functools.reduce(lambda dct, key: dct[key], keys, d)

--- a/seerpy/utils.py
+++ b/seerpy/utils.py
@@ -524,47 +524,6 @@ def quote_str(value):
     return f'"{value}"'
 
 
-def raises_error(error, func, *args, **kwargs):
-    """
-    Given an Error, a function object, along with the arguments and keyword
-    arguments to pass to the function, it returns True, of calling the function
-    with those arguments raises the error you expected.
-
-    Parameters
-    ----------
-    error: Exception object
-        The Error/Exception you expect to be thrown
-    func:   function object
-        The function to run
-    *args:
-        positional arguments to pass to `func`
-    **kwargs:
-        keyword arguments to pass to `func`
-
-    Returns
-    ----------
-    bool
-        Whether it throws the expected error
-
-    Examples
-    ----------
-    >>> raises_error(ZeroDivisionError, lambda x: x/0, 4)
-    True
-
-    Tests
-    ----------
-    >>> assert raises_error(ZeroDivisionError, lambda x: x/0, 4), "Failed Test"
-    >>> assert raises_error(FileNotFoundError, lambda x: x/0, 4) == False, "Failed Test"
-    >>> assert raises_error(KeyError, lambda d, k: d[k], dict(b=42), "c"), "Failed Test"
-    """
-    try:
-        func(*args, **kwargs)
-    except error:
-        return True
-    except:
-        return False
-
-
 def get_nested_dict_item(dct, keys, allow_missing_keys=False, default=None):
     """
     Given a dictionary with potentially many nested dictionaries, get the

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='seerpy',
-    version='0.4.0',
+    version='0.5.0',
     description='Seer Platform SDK for Python',
     long_description=open('README.md').read(),
     url='https://github.com/seermedical/seer-py',


### PR DESCRIPTION
I have added the `max_items` parameter to the following functions.

```python
get_paginated_response()

get_studies()
get_studies_dataframe()
get_patients()
get_mood_survey_results()
get_mood_survey_results_dataframe()
get_labels()
get_labels_dataframe()
get_diary_insights()
get_user_ids_in_user_cohort()
get_study_ids_in_study_cohort()
get_diary_study_labels()
get_diary_study_labels_dataframe()
```

## Ommited

I have not added `max_items` to the following functions

```python
get_organizations()                 # number of organizations is too few, so didnt implement
                                    # pagination
get_organisations_dataframe()

get_all_bookings()                  # Underlying GraphQL query for Bookings does not support
                                    # pagination. But i did allow  for a `includeCancelled` option
                                    # to be used
get_all_bookings_dataframe()        # As above

get_diary_study_label_groups()      # As per a TODO comment in the function, its unlikely that we
                                    # will get more than 20 items
get_diary_study_label_groups_dataframe() # As above

get_diary_labels()                  # Contains nesting that would make it unintuitive to use
                                    # `max_items`
                                    # eg, for each user, the results can contain contain multiple
                                    # `labelGroups` and for each `labelGroup` there can be multiple
                                    # `labels`
get_diary_labels_dataframe()        # As above


get_diary_medication_alerts()       # Contains nesting that would make it unintuitive to use
                                    # `max_items`
                                    # multiple items at the ["alerts"] level
                                    # multiple items at the ["alerts", "labels"] level
                                    # multiple items at the ["alerts", "labels", "doses"] level
get_diary_medication_alert_windows()# Contains nesting that would make it unintuitive to use
                                    # `max_items`
                                    # multiple items at ["alerts"] level
                                    # multiple items at ["alerts", "windows"] level
```

Also, ones that we could potentially add the option to in the future

```python
get_diary_study_channel_groups()    # currenlty it runs as a single query call.
                                    # how many channel groups are there for diary studies?
                                    # could it benefit from having a max_limit

get_diary_study_channel_groups_dataframe() # As above
```


## Testing

I have performed some preliminary sanity checks on the following:

```python
get_studies()
get_studies_dataframe()
get_patients()
get_mood_survey_results()
get_mood_survey_results_dataframe()
```

Ones I havent tested so far

```python
get_labels()
get_labels_dataframe()

get_diary_insights()                # Havent found any records with diary insights to check
get_user_ids_in_user_cohort()       # Havent found any any cohort ids to check
get_study_ids_in_study_cohort()     # havent found any study cohort ids to check

get_diary_study_labels()            # havnt found any patients with diary study labels to check
get_diary_study_labels_dataframe()  # as above
```



