### PR TITLE
Avoid using empty SDK API URL from env vars

### DIFF
--- a/seerpy/auth.py
+++ b/seerpy/auth.py
@@ -303,7 +303,7 @@ class SeerApiKeyAuth(BaseAuth):
                                                                     region)
 
         if not api_url:
-            api_url = os.getenv('SDK_API_BASE_URL', f'https://sdk-{region}.seermedical.com/api')
+            api_url = os.getenv('SDK_API_BASE_URL') or f'https://sdk-{region}.seermedical.com/api'
 
         super(SeerApiKeyAuth, self).__init__(api_url)
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='seerpy',
-    version='0.4.0',
+    version='0.4.1',
     description='Seer Platform SDK for Python',
     long_description=open('README.md').read(),
     url='https://github.com/seermedical/seer-py',


### PR DESCRIPTION
# Description
If an empty `SDK_API_BASE_URL` environment variable is found, `seer-py` will try using that as the auth `api_url` and fail. This has caused a little trouble in testing lambdas using AWS SAM, as they export this variable as empty when the `Env` parameter isn't set - which it isn't for local testing.

This tiny change will fall back to the `f'https://sdk-{region}.seermedical.com/api'` endpoint in that case.

For example, see:
https://github.com/seermedical/seer-api-events/blob/8e74354ebc22d28d2555d8726b93392423d774e3/apps/tedsZendeskTickets/template.yaml#L72