### PR TITLE
Added a new graphql call to fetch >5000 segment IDs 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -110,3 +110,6 @@ venv.bak/
 # vscode
 .vscode
 .idea/
+
+# Pre-commit
+.pre-commit-config.yaml

--- a/seerpy/graphql.py
+++ b/seerpy/graphql.py
@@ -231,6 +231,30 @@ def get_channel_groups_query_string(study_id):
         }""" % study_id
 
 
+def get_channel_group_segments_paged(channel_group_id, limit = 500, after=""):
+    return """
+        query segments {
+            resource {
+                channelGroupSegment {
+                list(
+                    filter:{ studyChannelGroupId:{ in: ["%s"]}}
+                    pagination: { limit: %.0f, after: "%s"}
+                ) {
+                    pageInfo {
+                    endCursor
+                    hasNextPage
+                    }
+                    items {
+                    id
+                    startTime
+                    duration
+                    timezone
+                    }
+                }
+                }
+            }
+            }""" % (channel_group_id, limit, after)
+
 #    studyChannelGroupSegments
 def get_segment_urls_query_string(segment_ids):
     segment_ids_string = get_json_list(segment_ids)

--- a/seerpy/seerpy.py
+++ b/seerpy/seerpy.py
@@ -664,7 +664,7 @@ class SeerConnect:  # pylint: disable=too-many-public-methods
         print(str(len(items)) + " items found")
         # convert list to dataframe
         items_df = pd.DataFrame(items)
-        return(items_df)
+        return items_df
 
 
     def get_segment_urls(self, segment_ids, limit=10000):

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='seerpy',
-    version='0.4.0',
+    version='0.4.2',
     description='Seer Platform SDK for Python',
     long_description=open('README.md').read(),
     url='https://github.com/seermedical/seer-py',


### PR DESCRIPTION
A new function to fetch segment ids for a channel group contining more than 5000 segments. The new function 'get_segment_ids' return a dataframe containing all segment ids in the channel group.

note: an existing function, 'get_paginated_response' could be used instead to achieve a similar result. However, the new function uses the new resource schema and it will run faster than the existing function.