### PR TITLE
Fix dataChunk.end for last chunk in segment

### DIFF
--- a/seerpy/seerpy.py
+++ b/seerpy/seerpy.py
@@ -776,7 +776,7 @@ class SeerConnect:  # pylint: disable=too-many-public-methods
             num_chunks = int(math.ceil(row[1] / chunk_period))
             for i in range(num_chunks):
                 chunk_start = row[2] + chunk_period * i
-                chunk_end = chunk_start + chunk_period
+                chunk_end = min(chunk_start + chunk_period, row[1] + row[2])
                 if chunk_end >= from_time and chunk_start <= to_time:
                     data_chunks.append({'segmentId': row[3], 'chunkIndex': i})
                     chunk_metadata.append({

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='seerpy',
-    version='0.6.0',
+    version='0.6.1',
     description='Seer Platform SDK for Python',
     long_description=open('README.md').read(),
     url='https://github.com/seermedical/seer-py',


### PR DESCRIPTION
Before this change, the `SeerConnect.get_data_chunk_urls` method assumed that all chunks were the full `chunk_period`. This is typically not true for the last chunk in each segment. As a result, the `chunkData.end` column in the returned dataframe was incorrect for the last chunk in each segment. 

This change ensures that the end of the last chunk matches `segments.startTime + segments.Duration`.