### PR TITLE
Pass `api_url` as correct param

### DIFF
--- a/seerpy/auth.py
+++ b/seerpy/auth.py
@@ -75,7 +75,7 @@ def get_auth(api_key_id=None, api_key_path=None, region=None, api_url=None, seer
                 (email or password or not (api_key_id or api_key_path or pem_files)))):
         return SeerAuth(api_url, email, password, timeout=timeout)
 
-    return SeerApiKeyAuth(api_key_id, api_key_path, region, api_url, timeout=timeout)
+    return SeerApiKeyAuth(api_key_id, api_key_path, region, api_url=api_url, timeout=timeout)
 
 
 # pylint: disable=no-self-use

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -76,7 +76,8 @@ class TestGetAuth:
 
         # check result
         assert isinstance(result, SeerApiKeyAuth)
-        seer_key_auth_init.assert_called_once_with(mock.ANY, None, None, None, None, timeout=None)
+        seer_key_auth_init.assert_called_once_with(mock.ANY, None, None, None, api_url=None,
+                                                   timeout=None)
 
     def test_email_false(self, mock_glob):
         # setup


### PR DESCRIPTION
In `get_auth`, args are passed in the wrong order to `SeerApiKeyAuth`, meaning the `api_url` is interpreted as the `api_key` at present.