### PR TITLE
Fix - Don't download EDF data by channel

### DIFF
--- a/Examples/downloader/downloader.py
+++ b/Examples/downloader/downloader.py
@@ -18,33 +18,42 @@ def get_download_log_file():
 
 
 class DataDownloader:
-    def __init__(self, client, study_id, path_out):
+    def __init__(self, client, study_id, path_out, channel_group_to_download=None):
         self.client = client
         self.study_id = study_id
         self.label_groups = self.get_label_groups()
-        self.channel_groups = self.get_channel_groups()
+        self.study_metadata = self.get_channel_groups_metadata()
+        self.channel_group_to_download = channel_group_to_download
 
-        self.study_name = self.channel_groups['name'][0]
+        self.study_name = self.study_metadata['name'][0]
         self.folder_out = join(path_out, self.study_name)
         if not isdir(self.folder_out):
             mkdir(self.folder_out)
 
-    def get_channel_groups(self):
-        return self.client.get_all_study_metadata_dataframe_by_ids([self.study_id])
+    def get_channel_groups_metadata(self):
+        channel_groups = self.client.get_all_study_metadata_dataframe_by_ids([self.study_id])
+        return channel_groups
 
     def get_label_groups(self):
         return self.client.get_label_groups_for_studies([self.study_id])
 
     def get_channels(self):
-        channels = self.channel_groups[['channelGroups.name', 'channels.name']].drop_duplicates()
-        return channels.to_numpy().tolist()
+        channels = self.study_metadata[['channelGroups.name', 'channels.name']].drop_duplicates()
+        return ([channel_group, channel] for channel_group, channel in zip(
+            channels['channelGroups.name'].tolist(), channels['channels.name'].tolist()))
 
-    def get_segment_data(self, folder_out, channel_group, channel, channel_metadata, segment_ids):
+    def get_segment_data(self, folder_out, channel_group, channels, channel_group_metadata,
+                         segment_ids):
         for index, segment_id in enumerate(tqdm(segment_ids)):
-            segment_metadata = channel_metadata[channel_metadata['segments.id'] == segment_id]
-            segment_file = join(
-                folder_out, f'{self.study_name}_{channel_group}_{channel}_segment_{index}.parquet')
-            if isfile(segment_file):
+            segment_metadata = channel_group_metadata[channel_group_metadata['segments.id'] ==
+                                                      segment_id]
+            segment_files_list = []
+            for channel in channels:
+                segment_files_list.append(
+                    join(folder_out,
+                         f'{self.study_name}_{channel_group}_{channel}_segment_{index}.parquet'))
+
+            if all([isfile(segment_file) for segment_file in segment_files_list]):
                 continue
             try:
                 segment_data = self.client.get_channel_data(segment_metadata)
@@ -54,43 +63,53 @@ class DataDownloader:
                 add_to_csv(log_file, segment_metadata)
                 continue
 
-            segment_row = segment_metadata.iloc[0, :]
+            raw_data_list = []
+            for channel in channels:
+                raw_data_list.append(
+                    pd.DataFrame({
+                        'time': segment_data['time'].tolist(),
+                        'data': segment_data[channel].tolist()
+                    }))
 
-            data = {}
-            data = pd.DataFrame({
-                'time': segment_data['time'].tolist(),
-                'data': segment_data[channel].tolist()
-            })
-
-            yield data, segment_file
+            yield raw_data_list, segment_files_list
 
     def download_channel_data(self):
         print(f'Downloading channel data for {self.study_name}...')
-
-        for (channel_group, channel) in self.get_channels():
+        for channel_group in self.study_metadata['channelGroups.name'].unique():
+            if self.channel_group_to_download is not None:
+                if not channel_group == self.channel_group_to_download:
+                    continue
+            print(channel_group, 'is in list to download.')
             # Create folder
             folder_out = join(self.folder_out, channel_group)
             if not isdir(folder_out):
                 mkdir(folder_out)
 
-            # Get channel metadata
-            channel_metadata_file = join(
-                self.folder_out, f'{self.study_name}_{channel_group}_{channel}_metadata.csv')
-            channel_metadata = self.channel_groups[
-                (self.channel_groups['channelGroups.name'] == channel_group)
-                & (self.channel_groups['channels.name'] == channel)]
+            channel_group_metadata = self.study_metadata[(
+                self.study_metadata['channelGroups.name'] == channel_group)]
+
+            # Get channels
+            channels = channel_group_metadata['channels.name'].unique()
             # Save channel metadata
-            channel_metadata.to_csv(channel_metadata_file)
+            for channel in channels:
+                # Get channel group metadata
+                channel_metadata = self.study_metadata[
+                    (self.study_metadata['channelGroups.name'] == channel_group)
+                    & (self.study_metadata['channels.name'] == channel)]
+                channel_metadata_file = join(
+                    self.folder_out, f'{self.study_name}_{channel_group}_{channel}_metadata.csv')
+                # Save channel metadata
+                channel_metadata.to_csv(channel_metadata_file)
 
             # Get segment IDs
-            segment_ids = channel_metadata['segments.id'].unique()
-            print(f'Progress for channel: {channel}')
+            segment_ids = channel_group_metadata['segments.id'].unique()
+            print(f'Progress for channel group: {channel_group} with channels: {channels}')
             # Get segment data
-            for segment_data, segment_file in self.get_segment_data(folder_out, channel_group,
-                                                                    channel, channel_metadata,
-                                                                    segment_ids):
-                # Save segment data to JSON
-                segment_data.to_parquet(segment_file)
+            for segment_data_list, segment_file_list in self.get_segment_data(
+                    folder_out, channel_group, channels, channel_group_metadata, segment_ids):
+                for segment_data, segment_file in zip(segment_data_list, segment_file_list):
+                    # Save segment data to JSON
+                    segment_data.to_parquet(segment_file)
         print('Done.')
 
     def download_label_data(self):

--- a/Examples/msg_data_downloader.py
+++ b/Examples/msg_data_downloader.py
@@ -11,7 +11,7 @@ from urllib3.exceptions import ReadTimeoutError
 from downloader.utils import read_json, write_json
 
 
-def get_download_status_file(client):
+def get_download_status_file():
     """Retrieves JSON of download status for all study IDs."""
     studies_file = join(dirname(__file__), 'studies.json')
     if not isfile(studies_file):
@@ -43,7 +43,7 @@ def run(client, path_out):
     if not isdir(output_dir):
         mkdir(output_dir)
 
-    download_status_file = get_download_status_file(client)
+    download_status_file = get_download_status_file()
     download_status = read_json(download_status_file)
     study_ids = [study_id for study_id in download_status if download_status[study_id] == 0]
 


### PR DESCRIPTION
Due to the way EDFs are structured and seer-py download function, data downloaded from S3 is reshaped based on the number of channel groups (i.e. column names).

By supplying a slice of the metadata, data is incorrectly reshaped.

This fix is a workaround-ish. Download data, then slice.

Could someone please pull this branch and do a sanity check - i.e. values are different between Empatica ACC channels? @EwanNurse @cfranklin11 