### PR TITLE
Fix get_paginated_response when `iteration_path` returns empty on first iteration

### DIFF
--- a/seerpy/seerpy.py
+++ b/seerpy/seerpy.py
@@ -217,6 +217,7 @@ class SeerConnect:  # pylint: disable=too-many-public-methods
         result = []
         total_items_returned = 0
 
+        is_first_iteration = True
         while True:
             # Update the number of items remaining
             # And set the limit for the final batch if needed
@@ -234,6 +235,10 @@ class SeerConnect:  # pylint: disable=too-many-public-methods
             # select the part of the response we are interested in
             response = utils.get_nested_dict_item(response, object_path)
 
+            # If first iteration, then assign the entire top level response to results 
+            if is_first_iteration:
+                result = response
+
             # select the part of the response which can vary. if iteration_path is None this will be
             # the same as the part of the response we are interested in
             response_increment = response
@@ -244,11 +249,10 @@ class SeerConnect:  # pylint: disable=too-many-public-methods
                 break
 
             # Update the number of items received
-            total_items_returned += len(response)
+            total_items_returned += len(response_increment)
 
-            if not result:
-                # if this is the first response, save it
-                result = response
+            if is_first_iteration:
+                is_first_iteration = False
             else:
                 # otherwise add the response increment to the existing result at the correct level
                 values_container = result

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='seerpy',
-    version='0.6.3',
+    version='0.6.4',
     description='Seer Platform SDK for Python',
     long_description=open('README.md').read(),
     url='https://github.com/seermedical/seer-py',

--- a/tests/test_data/no_label_groups_for_studies.py
+++ b/tests/test_data/no_label_groups_for_studies.py
@@ -1,0 +1,41 @@
+"""
+Data for mocking intermediate function calls, as well as expected return values 
+when testing the following functions: 
+- client.get_label_groups_for_studies()
+- client.get_label_groups_for_studies_dataframe()
+
+For condition in which the studies do not contain any label groups.
+"""
+import io
+import pandas as pd
+
+# Individual responses it gets from calling client.get_label_groups_for_study()
+individual_study_responses = [
+    {
+        "id": "study1_id",
+        "name": "study1_name",
+        "labelGroups": []
+    },
+    {
+        "id": "study2_id",
+        "name": "study2_name",
+        "labelGroups": []
+    }
+]
+
+# The expected result from client.get_label_groups_for_studies()
+expected_seerpy_response = [
+    {
+        "id": "study1_id",
+        "name": "study1_name",
+        "labelGroups": []
+    },
+    {
+        "id": "study2_id",
+        "name": "study2_name",
+        "labelGroups": []
+    },
+]
+
+# The expected result from client.get_label_groups_for_studies_dataframe()
+expected_seerpy_df = pd.DataFrame([])

--- a/tests/test_data/no_label_groups_for_study.py
+++ b/tests/test_data/no_label_groups_for_study.py
@@ -1,0 +1,27 @@
+"""
+Data for mocking intermediate function calls, as well as expected return values 
+when testing the following function: 
+- client.get_label_groups_for_study()
+
+For condition in which the study does not contain any label groups.
+"""
+
+# Mocked paginated responses on each subsequent call of client.execute_query()
+# within the client.get_paginated_response() function that gets called by 
+# client.get_label_groups_for_study()
+raw_paginated_responses = [
+    {
+        "study": {
+            "id": "study1_id",
+            "name": "study1_name",
+            "labelGroups": []
+        }
+    },
+]
+
+# Expected return value when calling client.get_label_groups_for_study()
+expected_seerpy_response = {
+    "id": "study1_id",
+    "name": "study1_name",
+    "labelGroups": []
+}


### PR DESCRIPTION
There is a bug with `get_paginated_response()` such that if you are using an `iteration_path`, and the data at the `iteration_path` level is empty, on the first iteration, then it returns an empty list, instead of the top level information.

E.g. for a function that calls it, such as `client.get_label_groups_for_study("1234")`

it should return

```js
{'id': '1234',
 'name': 'someStudyName',
 'labelGroups': []}
```

But currently returns

```js
[]
```

Fixed it so it returns the correct thing.
