### PR TITLE
Fix Pip Dependencies 

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ gql==3.0.0
 requests==2.27.1
 numpy==1.22.1
 pandas==1.4.0
+argparse==1.4.0
 graphql-core==3.2.0
 requests-toolbelt==0.9.1
 pyjwt[crypto]==2.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,10 @@
 gql==3.0.0
-requests==2.27.1
-numpy==1.22.1
-pandas==1.4.0
-argparse==1.4.0
-graphql-core==3.2.0
+requests
+numpy
+pandas
+argparse
 requests-toolbelt==0.9.1
-pyjwt[crypto]==2.3.0
-tqdm==4.62.3
+graphql-core==3.2.0
+pyjwt[crypto]
+tqdm
 -e .

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,9 @@
-gql
-requests
-numpy
-pandas
-# TODO: graphql-core 3.0.0 has a problem as at 02/12/2019
-# revisit in the future, we may be able to remove the restriction
-graphql-core<3.0.0
-pyjwt[crypto]
-tqdm
+gql==3.0.0
+requests==2.27.1
+numpy==1.22.1
+pandas==1.4.0
+graphql-core==3.2.0
+requests-toolbelt==0.9.1
+pyjwt[crypto]==2.3.0
+tqdm==4.62.3
 -e .


### PR DESCRIPTION
Gql just got updated from 2.0.0 to 3.0.0. This is a breaking change, as it requires requests-toolbelt to be installed.
This means a current build of Seer-py right now won't work.

This PR adds the required deps, and pins all python deps to something sensible so that this is less likely to happen in the future.