### PR TITLE
Simplify installation dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,7 @@
-gql==3.0.0
-requests
+gql[requests]==3.0.0
+graphql-core==3.2.0
 numpy
 pandas
-argparse
-requests-toolbelt==0.9.1
-graphql-core==3.2.0
 pyjwt[crypto]
 tqdm
 -e .

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
     ],
     keywords='api seer eeg ecg client',
     packages=find_packages(include=["seerpy*"]),
-    install_requires=['gql[requests]', 'numpy', 'pandas', 'pyjwt[crypto]'],
+    install_requires=['gql[requests]>=3', 'numpy', 'pandas', 'pyjwt[crypto]'],
     extras_require={'viz': ['matplotlib']},
     tests_require=['pytest'],
 )

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,3 @@
-from pathlib import Path
 from setuptools import setup, find_packages
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='seerpy',
-    version='0.6.4',
+    version='0.6.5',
     description='Seer Platform SDK for Python',
     long_description=open('README.md').read(),
     url='https://github.com/seermedical/seer-py',
@@ -19,7 +19,7 @@ setup(
     ],
     keywords='api seer eeg ecg client',
     packages=find_packages(include=["seerpy*"]),
-    install_requires=['gql', 'requests', 'numpy', 'pandas', 'pyjwt[crypto]', 'requests-toolbelt'],
+    install_requires=['gql[requests]', 'numpy', 'pandas', 'pyjwt[crypto]'],
     extras_require={'viz': ['matplotlib']},
     tests_require=['pytest'],
 )


### PR DESCRIPTION
Switch to installing the `gql` dependency using the recommended approach, as per [the docs](https://gql.readthedocs.io/en/latest/intro.html#installation).